### PR TITLE
Align ASGI with env-based settings

### DIFF
--- a/holytrail/asgi.py
+++ b/holytrail/asgi.py
@@ -11,6 +11,12 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'holytrail.settings')
+if "ENVIRONMENT_NAME" in os.environ:
+    environment_name = os.environ["ENVIRONMENT_NAME"]
+    environment_settings_file = "holytrail.settings." + environment_name
+else:
+    environment_settings_file = "holytrail.settings.base"
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", environment_settings_file)
 
 application = get_asgi_application()


### PR DESCRIPTION
## Summary
- update `holytrail/asgi.py` to honor `ENVIRONMENT_NAME` like `wsgi.py` and `manage.py`

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'django_ckeditor_5')*
- `python - <<'PY'
import os
os.environ['ENVIRONMENT_NAME'] = 'production'
try:
    from holytrail import asgi
    from django.conf import settings
    print('settings module:', settings.SETTINGS_MODULE)
except Exception as e:
    print('Error:', e)
PY` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cc2096064832d9a27115d02614feb