### PR TITLE
Fix CKEditor custom CSS reference

### DIFF
--- a/holytrail/settings/base.py
+++ b/holytrail/settings/base.py
@@ -243,7 +243,6 @@ CKEDITOR_5_CONFIGS = {
         "language": "en"
     }
 }
-CKEDITOR_5_CUSTOM_CSS = "css/gotur.css"
 
 
 

--- a/holytrail/settings/production.py
+++ b/holytrail/settings/production.py
@@ -244,7 +244,6 @@ CKEDITOR_5_CONFIGS = {
         "language": "en"
     }
 }
-CKEDITOR_5_CUSTOM_CSS = "css/gotur.css"
 
 
 CKEDITOR_5_UPLOADS_PATH = 'uploads/'  # This handles image/file uploads in editor


### PR DESCRIPTION
## Summary
- deduplicate `CKEDITOR_5_CUSTOM_CSS` setting so both envs use `editor-custom.css`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc302eea8832da45a572d82d34bec