### PR TITLE
Use env variables for admin email lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Holytrail
+
+This Django project powers the Holytrail website. It contains the application code and configuration used to run the site.
+
+## Environment Variables
+
+Some features rely on environment variables. When sending booking notifications from `checkout_view`, the following variables control the recipient addresses:
+
+- `ADMIN_EMAILS` &mdash; Comma-separated list of email addresses that should receive the booking details. If unset, defaults to `vipul57612@gmail.com`.
+- `CC_EMAILS` &mdash; Comma-separated list of addresses that will be copied on the same email. If unset, defaults to `rishabhpandey101@gmail.com`.
+
+Set these variables in your deployment environment to customise who receives order notifications.

--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -71,12 +71,17 @@ def checkout_view(request):
         Total: ₹{total_amount}
         '''
         
+        admin_emails = [email.strip() for email in os.getenv(
+            'ADMIN_EMAILS', 'vipul57612@gmail.com').split(',') if email.strip()]
+        cc_emails = [email.strip() for email in os.getenv(
+            'CC_EMAILS', 'rishabhpandey101@gmail.com').split(',') if email.strip()]
+
         admin_email = EmailMultiAlternatives(
-            admin_subject, 
-            admin_message, 
-            settings.DEFAULT_FROM_EMAIL, 
-            ['vipul57612@gmail.com'],  # To (admin email)
-            cc=['rishabhpandey101@gmail.com']  # CC email(s)
+            admin_subject,
+            admin_message,
+            settings.DEFAULT_FROM_EMAIL,
+            admin_emails,
+            cc=cc_emails
             )
         if screenshot_content:
             admin_email.attach(screenshot_name, screenshot_content, screenshot_type)


### PR DESCRIPTION
## Summary
- read `ADMIN_EMAILS` and `CC_EMAILS` from environment for admin email list
- document new variables in a README

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'django_ckeditor_5')*

------
https://chatgpt.com/codex/tasks/task_e_686cc3b740c4832dbda83fcfbe66a26b