### PR TITLE
Use env SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This Django project powers the Holytrail website. It contains the application co
 
 ## Environment Variables
 
-Some features rely on environment variables. When sending booking notifications from `checkout_view`, the following variables control the recipient addresses:
+Some features rely on environment variables. The application expects the following keys:
 
+- `SECRET_KEY` &mdash; The Django secret key used for cryptographic signing. This is required in production, but `settings.base` falls back to a default value for local development.
 - `ADMIN_EMAILS` &mdash; Comma-separated list of email addresses that should receive the booking details. If unset, defaults to `vipul57612@gmail.com`.
 - `CC_EMAILS` &mdash; Comma-separated list of addresses that will be copied on the same email. If unset, defaults to `rishabhpandey101@gmail.com`.
 
-Set these variables in your deployment environment to customise who receives order notifications.
+Set these variables in your deployment environment to customise who receives order notifications and to configure Django securely.

--- a/holytrail/settings/base.py
+++ b/holytrail/settings/base.py
@@ -22,7 +22,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-864p+t^0re3pz01cp1fcfj!@sh7)j)z*cj+6#+z*(8xq55pv^&'
+# Falls back to the original development key when the environment variable
+# is unset so the project can run locally without additional configuration.
+SECRET_KEY = os.environ.get(
+    "SECRET_KEY",
+    "django-insecure-864p+t^0re3pz01cp1fcfj!@sh7)j)z*cj+6#+z*(8xq55pv^&",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 #DEBUG = True

--- a/holytrail/settings/production.py
+++ b/holytrail/settings/production.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-864p+t^0re3pz01cp1fcfj!@sh7)j)z*cj+6#+z*(8xq55pv^&'
+SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 #DEBUG = True


### PR DESCRIPTION
## Summary
- read `SECRET_KEY` from environment
- allow fallback only in the development settings
- document the new environment variable

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'django_ckeditor_5')*
- `python manage.py check` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cc604772c832d98cc02fab8656e8d