### PR TITLE
Fix gitignore for base settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,3 @@ cython_debug/
 
 #folders
 media/
-holytrail/settings/base.py


### PR DESCRIPTION
## Summary
- stop ignoring `holytrail/settings/base.py`

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686ccd0d0f9c832db2a061fe2937f84a