### PR TITLE
Add full project setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,58 @@
 
 This Django project powers the Holytrail website. It contains the application code and configuration used to run the site.
 
+## Installation
+
+1. Clone the repository and switch into the project directory:
+   ```bash
+   git clone <REPO_URL>
+   cd holytrail
+   ```
+2. Create and activate a virtual environment:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+3. Install the required packages:
+   ```bash
+   pip install django jazzmin django-ckeditor-5
+   ```
+   *(Alternatively, install from a `requirements.txt` file if you maintain one.)*
+
 ## Environment Variables
 
-Some features rely on environment variables. The application expects the following keys:
+Some features rely on environment variables. At a minimum set the following keys:
 
-- `SECRET_KEY` &mdash; The Django secret key used for cryptographic signing. This is required in production, but `settings.base` falls back to a default value for local development.
-- `ADMIN_EMAILS` &mdash; Comma-separated list of email addresses that should receive the booking details. If unset, defaults to `vipul57612@gmail.com`.
-- `CC_EMAILS` &mdash; Comma-separated list of addresses that will be copied on the same email. If unset, defaults to `rishabhpandey101@gmail.com`.
+- `SECRET_KEY` – Secret key for cryptographic signing. `settings.base` uses a fallback when running locally.
+- `ENVIRONMENT_NAME` – Optional setting that chooses which settings module is loaded (`base` by default or `production`).
+- `ADMIN_EMAILS` – Comma-separated list of email addresses that should receive the booking details. Defaults to `vipul57612@gmail.com`.
+- `CC_EMAILS` – Comma-separated list of addresses that will be copied on the same email. Defaults to `rishabhpandey101@gmail.com`.
+- `EMAIL_HOST_USER` / `EMAIL_HOST_PASSWORD` – SMTP credentials used when sending mail in the production configuration.
+- `DATABASE_USER` / `DATABASE_PASSWORD` – PostgreSQL credentials when using the production settings file.
 
-Set these variables in your deployment environment to customise who receives order notifications and to configure Django securely.
+Set these variables in your deployment environment to configure email notifications and database access and to keep Django secure.
+
+## Running the Development Server
+
+Apply any pending migrations and start the built-in server:
+
+```bash
+python manage.py migrate
+python manage.py runserver
+```
+
+If you wish to use a different settings module (for example the production configuration), set `ENVIRONMENT_NAME` accordingly before running the command.
+
+## Running Tests
+
+Run the Django test suite with:
+
+```bash
+python manage.py test
+```
+
+There is also a small standalone script used by CI which simply imports CKEditor:
+
+```bash
+python test.py
+```


### PR DESCRIPTION
## Summary
- document installation steps
- detail all environment variables
- explain how to run the server and tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python test.py` *(fails: ModuleNotFoundError: No module named 'django_ckeditor_5')*

------
https://chatgpt.com/codex/tasks/task_e_686ccdb4cf2c832d9fd258840f06ce96