### PR TITLE
Fix duplicate route names

### DIFF
--- a/tour/urls.py
+++ b/tour/urls.py
@@ -6,5 +6,6 @@ app_name = "tour"
 urlpatterns = [
     path("", views.tour_view, name="tour"),
     path("tour-detail/", views.tourdetail_view, name="tour-detail"),
-    path("tour-details/", views.tourdetails_view, name="tour-detail"),
+    # Ensure a unique name for the tour-details route
+    path("tour-details/", views.tourdetails_view, name="tour-details"),
 ]


### PR DESCRIPTION
## Summary
- ensure unique names for tour detail routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ccfb68d3c832d995aa34fa7c7f953