### PR TITLE
Add policy pages with routing and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ Run the Django test suite with:
 ```bash
 python manage.py test
 ```
+
+## Policies
+
+Editable templates for common policies are located in `templates/`:
+
+- `privacy_policy.html`
+- `terms_and_conditions.html`
+- `cancellation_refund.html`
+- `shipping_delivery.html`
+
+Update these files to change the text shown on the corresponding pages.

--- a/home/urls.py
+++ b/home/urls.py
@@ -12,5 +12,9 @@ urlpatterns = [
     path("blog", views.blog_view, name="blog"),
     path("destination", views.destination_view, name="destination"),
     path("cart",  views.cart_view, name="cart"),
-    
+    path("privacy-policy/", views.privacy_policy_view, name="privacy_policy"),
+    path("terms-and-conditions/", views.terms_and_conditions_view, name="terms_and_conditions"),
+    path("cancellation-refund/", views.cancellation_refund_view, name="cancellation_refund"),
+    path("shipping-delivery/", views.shipping_delivery_view, name="shipping_delivery"),
+
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -33,3 +33,15 @@ def destination_view(request):
 def cart_view(request):
     return render(request, "cart.html")
 
+def privacy_policy_view(request):
+    return render(request, "privacy_policy.html")
+
+def terms_and_conditions_view(request):
+    return render(request, "terms_and_conditions.html")
+
+def cancellation_refund_view(request):
+    return render(request, "cancellation_refund.html")
+
+def shipping_delivery_view(request):
+    return render(request, "shipping_delivery.html")
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -325,6 +325,10 @@
                                     <li><a href="/">News & blog</a></li>
                                     <li><a href="/">Meet the Guide</a></li>
                                     <li><a href="contact">Contacts</a></li>
+                                    <li><a href="privacy-policy/">Privacy Policy</a></li>
+                                    <li><a href="terms-and-conditions/">Terms &amp; Conditions</a></li>
+                                    <li><a href="cancellation-refund/">Cancellation &amp; Refund</a></li>
+                                    <li><a href="shipping-delivery/">Shipping &amp; Delivery</a></li>
                                 </ul><!-- /.list-unstyled footer-widget__links -->
                             </div><!-- /.footer-widget -->
                         </div><!-- /.col-lg-6 -->

--- a/templates/cancellation_refund.html
+++ b/templates/cancellation_refund.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block doc_title %}Cancellation and Refund{% endblock %}
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <div class="page-header__content">
+            <h2 class="page-header__title">Cancellation &amp; Refund Policy</h2>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/privacy_policy.html
+++ b/templates/privacy_policy.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block doc_title %}Privacy Policy{% endblock %}
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <div class="page-header__content">
+            <h2 class="page-header__title">Privacy Policy</h2>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/shipping_delivery.html
+++ b/templates/shipping_delivery.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block doc_title %}Shipping and Delivery{% endblock %}
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <div class="page-header__content">
+            <h2 class="page-header__title">Shipping &amp; Delivery Policy</h2>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/terms_and_conditions.html
+++ b/templates/terms_and_conditions.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block doc_title %}Terms and Conditions{% endblock %}
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <div class="page-header__content">
+            <h2 class="page-header__title">Terms and Conditions</h2>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+class PolicyPagesTests(TestCase):
+    def test_privacy_policy_page(self):
+        response = self.client.get('/privacy-policy/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_terms_page(self):
+        response = self.client.get('/terms-and-conditions/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_cancellation_refund_page(self):
+        response = self.client.get('/cancellation-refund/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_shipping_delivery_page(self):
+        response = self.client.get('/shipping-delivery/')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- add privacy policy, terms, refund, and shipping templates
- add views for policy pages
- register URLs for new views
- link to policies in site footer
- test policy page endpoints
- document policy pages in README

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6887b3728ce8832d9aa8ff8ddc4e7bc5