### PR TITLE
Extend booking options in tour forms

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -15,6 +15,7 @@ def checkout_view(request):
     adult_total = request.GET.get('adult_total', '0')
     youth_total = request.GET.get('youth_total', '0')
     total_amount = request.GET.get('total_amount', '0')
+    booking_option = request.GET.get('booking_option', 'family')
 
     client = razorpay.Client(auth=(settings.RAZORPAY_KEY_ID, settings.RAZORPAY_KEY_SECRET))
     order = client.order.create({
@@ -29,6 +30,7 @@ def checkout_view(request):
         'adult_total': adult_total,
         'youth_total': youth_total,
         'total_amount': total_amount,
+        'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
         'razorpay_order_id': order['id'],
         'razorpay_key_id': settings.RAZORPAY_KEY_ID,
     }
@@ -59,6 +61,7 @@ def verify_payment_view(request):
     state = request.POST.get('state')
     zip_code = request.POST.get('zip-code')
     email = request.POST.get('email')
+    booking_option = request.POST.get('booking_option', 'family')
     adults = request.POST.get('adults')
     youths = request.POST.get('youths')
     adult_total = request.POST.get('adult_total')
@@ -78,6 +81,7 @@ def verify_payment_view(request):
         'adult_total': adult_total,
         'youth_total': youth_total,
         'total_amount': total_amount,
+        'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
     }).content.decode('utf-8')
     text_content = strip_tags(html_content)
 
@@ -92,6 +96,7 @@ def verify_payment_view(request):
     Phone: {phone}
     Email: {email}
     Address: {address}, {city}, {state}, {zip_code}
+    Booking Option: {'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)'}
     Adults: {adults} (₹{adult_total})
     Youths: {youths} (₹{youth_total})
     Total: ₹{total_amount}

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -82,6 +82,7 @@
                         <input type="hidden" name="adult_total" value="{{ adult_total }}" />
                         <input type="hidden" name="youth_total" value="{{ youth_total }}" />
                         <input type="hidden" name="total_amount" value="{{ total_amount }}" />
+                        <input type="hidden" name="booking_option" value="{{ booking_option }}" />
                         <input type="hidden" name="razorpay_order_id" value="{{ razorpay_order_id }}" />
                         <button type="button" id="pay-button" class="gotur-btn gotur-btn--base">
                             Pay with Razorpay
@@ -103,6 +104,10 @@
                             </tr>
                         </thead>
                         <tbody>
+                            <tr>
+                                <td class="pro__title">Option</td>
+                                <td class="pro__price">{{ booking_option|title }}</td>
+                            </tr>
                             <tr>
                                 <td class="pro__title">For {{ adults }} Adult</td>
                                 <td class="pro__price">₹{{ adult_total }}</td>

--- a/templates/emails/admin_order_details.html
+++ b/templates/emails/admin_order_details.html
@@ -21,6 +21,8 @@
         <p><strong>Phone:</strong> {{ phone }}</p>
         <p><strong>Address:</strong> {{ address }}, {{ town_city }}, {{ state }} - {{ zip_code }}</p>
 
+        <p><strong>Booking Option:</strong> {{ booking_option }}</p>
+
         <h3>Booking Summary</h3>
         <table class="details-table">
             <tr><th>Item</th><th>Qty</th><th>Amount</th></tr>

--- a/templates/emails/customer_confirmation.html
+++ b/templates/emails/customer_confirmation.html
@@ -23,6 +23,7 @@
             <li><strong>Email:</strong> {{ email }}</li>
             <li><strong>Phone:</strong> {{ phone }}</li>
             <li><strong>Address:</strong> {{ address }}, {{ town_city }}, {{ state }} - {{ zip_code }}</li>
+            <li><strong>Booking Option:</strong> {{ booking_option }}</li>
         </ul>
 
         <h3>Order Summary</h3>

--- a/templates/emails/order_confirmation.html
+++ b/templates/emails/order_confirmation.html
@@ -18,6 +18,7 @@
 
                 <h3>Booking Summary:</h3>
                 <ul>
+                    <li><strong>Booking Option:</strong> {{ booking_option }}</li>
                     <li><strong>Adults:</strong> {{ adults }} (₹{{ adult_total }})</li>
                     <li><strong>Youths:</strong> {{ youths }} (₹{{ youth_total }})</li>
                     <li><strong>Total Amount:</strong> ₹{{ total_amount }}</li>

--- a/templates/tour-detail.html
+++ b/templates/tour-detail.html
@@ -581,9 +581,17 @@
                         <h4 class="tour-listing-details__sidebar__title" id="book-now">Book This Tour</h4>
                         <!-- /.tour-listing-details__sidebar__title -->
                         <div class="sidebar-two__form">
+                            <p class="booking-option-info">Choose between a private family trip or a shared youth group experience.</p>
                             <form class="sidebar-two__form__inner contact-form-validated" action="checkout"
                                 method="POST" novalidate="novalidate">
                                 {% csrf_token %}
+                                <div class="sidebar-two__form__control">
+                                    <label>Booking Option:</label>
+                                    <div class="booking-option-choice">
+                                        <label><input type="radio" name="booking_option" value="family" checked> Family / Individual (Private)</label>
+                                        <label style="margin-left:10px;"><input type="radio" name="booking_option" value="youth"> Youth Group (Shared)</label>
+                                    </div>
+                                </div>
                                 <div class="sidebar-two__form__control">
                                     <label for="adult">Adult:</label>
                                     <input id="adult" type="number" name="adult" placeholder="Enter Value" value="0"
@@ -593,9 +601,10 @@
                                     <label for="youth">Youth:</label>
                                     <input id="youth" type="number" name="youth" placeholder="Enter Value" value="0"
                                         min="0">
+                                    <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
                                 </div>
                                 <input type="hidden" id="checkout" name="checkout">
-                                <div class="sidebar-two__form__control sidebar-two__form__control--two">
+                                <div class="sidebar-two__form__control sidebar-two__form__control--two adult-transport">
                                     <label class="sidebar-two__form__control--title" for="guests">Option for
                                         Adults:</label>
                                     <ul class="list-unstyled sidebar-two__form__checkbox">
@@ -628,6 +637,7 @@
 
                                 <!-- Hidden input to send final total to payment page -->
                                 <input type="hidden" name="final_amount" id="final_amount">
+                                <input type="hidden" name="booking_option" id="booking_option_field">
                                 <button type="button" id="goToCheckout" class="gotur-btn gotur-btn--base">Book Now <i
                                         class="icon-right"></i></button>
                             </form>
@@ -650,6 +660,29 @@
     const totalAmountDisplay = document.getElementById('totalAmount');
     const finalAmountInput = document.getElementById('final_amount');
     const checkoutInput = document.getElementById('checkout');
+    const bookingOptionField = document.getElementById('booking_option_field');
+    const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
+    const transportSection = document.querySelector('.adult-transport');
+    const childNote = document.getElementById('child-note');
+
+    function updateOption() {
+        const selected = document.querySelector('input[name="booking_option"]:checked').value;
+        bookingOptionField.value = selected;
+        if (selected === 'youth') {
+            transportSection.style.display = 'none';
+            checkTraveller.checked = true;
+            checkTraveller.disabled = true;
+            checkInnova.checked = false;
+            checkInnova.disabled = true;
+            if (childNote) childNote.style.display = 'none';
+        } else {
+            transportSection.style.display = '';
+            checkTraveller.disabled = false;
+            checkInnova.disabled = false;
+            if (childNote) childNote.style.display = '';
+        }
+        calculateTotal();
+    }
 
     function calculateTotal() {
         const youthPrice = 8000;
@@ -690,6 +723,7 @@
 
     adultInput.addEventListener('input', calculateTotal);
     youthInput.addEventListener('input', calculateTotal);
+    bookingRadios.forEach(r => r.addEventListener('change', updateOption));
     checkInnova.addEventListener('change', () => {
         if (checkInnova.checked) checkTraveller.checked = false;
         calculateTotal();
@@ -700,7 +734,7 @@
     });
 
     // Initial run
-    calculateTotal();
+    updateOption();
 
     const goToCheckoutBtn = document.getElementById('goToCheckout');
 
@@ -720,6 +754,7 @@
             adult_total: vals.adultTotal || 0,
             youth_total: vals.youthTotal || 0,
             total_amount: vals.total || 0,
+            booking_option: bookingOptionField.value || 'family'
         });
 
         window.location.href = `/checkout/?${params.toString()}`;

--- a/templates/tour-details.html
+++ b/templates/tour-details.html
@@ -591,9 +591,17 @@
                         <h4 class="tour-listing-details__sidebar__title">Book This Tour</h4>
                         <!-- /.tour-listing-details__sidebar__title -->
                         <div class="sidebar-two__form">
+                            <p class="booking-option-info">Choose between a private family trip or a shared youth group experience.</p>
                             <form class="sidebar-two__form__inner contact-form-validated" action="checkout"
                                 method="POST" novalidate="novalidate">
                                 {% csrf_token %}
+                                <div class="sidebar-two__form__control">
+                                    <label>Booking Option:</label>
+                                    <div class="booking-option-choice">
+                                        <label><input type="radio" name="booking_option" value="family" checked> Family / Individual (Private)</label>
+                                        <label style="margin-left:10px;"><input type="radio" name="booking_option" value="youth"> Youth Group (Shared)</label>
+                                    </div>
+                                </div>
                                 <div class="sidebar-two__form__control">
                                     <label for="adult">Adult:</label>
                                     <input id="adult" type="number" name="adult" placeholder="Enter Value" value="0"
@@ -603,9 +611,10 @@
                                     <label for="youth">Youth:</label>
                                     <input id="youth" type="number" name="youth" placeholder="Enter Value" value="0"
                                         min="0">
+                                    <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
                                 </div>
                                 <input type="hidden" id="checkout" name="checkout">
-                                <div class="sidebar-two__form__control sidebar-two__form__control--two">
+                                <div class="sidebar-two__form__control sidebar-two__form__control--two adult-transport">
                                     <label class="sidebar-two__form__control--title" for="guests">Option for
                                         Adults:</label>
                                     <ul class="list-unstyled sidebar-two__form__checkbox">
@@ -638,6 +647,7 @@
 
                                 <!-- Hidden input to send final total to payment page -->
                                 <input type="hidden" name="final_amount" id="final_amount">
+                                <input type="hidden" name="booking_option" id="booking_option_field">
                                 <button type="button" id="goToCheckout" class="gotur-btn gotur-btn--base">Book Now <i
                                         class="icon-right"></i></button>
                             </form>
@@ -660,6 +670,29 @@
     const totalAmountDisplay = document.getElementById('totalAmount');
     const finalAmountInput = document.getElementById('final_amount');
     const checkoutInput = document.getElementById('checkout');
+    const bookingOptionField = document.getElementById('booking_option_field');
+    const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
+    const transportSection = document.querySelector('.adult-transport');
+    const childNote = document.getElementById('child-note');
+
+    function updateOption() {
+        const selected = document.querySelector('input[name="booking_option"]:checked').value;
+        bookingOptionField.value = selected;
+        if (selected === 'youth') {
+            transportSection.style.display = 'none';
+            checkTraveller.checked = true;
+            checkTraveller.disabled = true;
+            checkInnova.checked = false;
+            checkInnova.disabled = true;
+            if (childNote) childNote.style.display = 'none';
+        } else {
+            transportSection.style.display = '';
+            checkTraveller.disabled = false;
+            checkInnova.disabled = false;
+            if (childNote) childNote.style.display = '';
+        }
+        calculateTotal();
+    }
 
     function calculateTotal() {
         const youthPrice = 8000;
@@ -700,6 +733,7 @@
 
     adultInput.addEventListener('input', calculateTotal);
     youthInput.addEventListener('input', calculateTotal);
+    bookingRadios.forEach(r => r.addEventListener('change', updateOption));
     checkInnova.addEventListener('change', () => {
         if (checkInnova.checked) checkTraveller.checked = false;
         calculateTotal();
@@ -710,7 +744,7 @@
     });
 
     // Initial run
-    calculateTotal();
+    updateOption();
 
     const goToCheckoutBtn = document.getElementById('goToCheckout');
 
@@ -730,6 +764,7 @@
             adult_total: vals.adultTotal || 0,
             youth_total: vals.youthTotal || 0,
             total_amount: vals.total || 0,
+            booking_option: bookingOptionField.value || 'family'
         });
 
         window.location.href = `/checkout/?${params.toString()}`;


### PR DESCRIPTION
## Summary
- support selecting booking option on tour detail pages
- include selected option at checkout and in confirmation emails
- note that kids over 5 need their own seat

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a0fc9a908832db8b28c74f1402c54