### PR TITLE
Simplify booking process

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -10,10 +10,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
     
 def checkout_view(request):
     # Always prepare a Razorpay order for the given amount
-    adults = request.GET.get('adults', '0')
-    youths = request.GET.get('youths', '0')
-    adult_total = request.GET.get('adult_total', '0')
-    youth_total = request.GET.get('youth_total', '0')
+    count = request.GET.get('count', '0')
     total_amount = request.GET.get('total_amount', '0')
     booking_option = request.GET.get('booking_option', 'family')
 
@@ -25,10 +22,7 @@ def checkout_view(request):
     })
 
     context = {
-        'adults': adults,
-        'youths': youths,
-        'adult_total': adult_total,
-        'youth_total': youth_total,
+        'count': count,
         'total_amount': total_amount,
         'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
         'razorpay_order_id': order['id'],
@@ -62,10 +56,7 @@ def verify_payment_view(request):
     zip_code = request.POST.get('zip-code')
     email = request.POST.get('email')
     booking_option = request.POST.get('booking_option', 'family')
-    adults = request.POST.get('adults')
-    youths = request.POST.get('youths')
-    adult_total = request.POST.get('adult_total')
-    youth_total = request.POST.get('youth_total')
+    count = request.POST.get('count')
     total_amount = request.POST.get('total_amount')
 
     html_content = render(request, 'emails/order_confirmation.html', {
@@ -76,10 +67,7 @@ def verify_payment_view(request):
         'state': state,
         'zip_code': zip_code,
         'email': email,
-        'adults': adults,
-        'youths': youths,
-        'adult_total': adult_total,
-        'youth_total': youth_total,
+        'count': count,
         'total_amount': total_amount,
         'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
     }).content.decode('utf-8')
@@ -97,8 +85,7 @@ def verify_payment_view(request):
     Email: {email}
     Address: {address}, {city}, {state}, {zip_code}
     Booking Option: {'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)'}
-    Adults: {adults} (₹{adult_total})
-    Youths: {youths} (₹{youth_total})
+    Count: {count}
     Total: ₹{total_amount}
     '''
 

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -77,10 +77,7 @@
                                 </div>
                             </div>
                         </div>
-                        <input type="hidden" name="adults" value="{{ adults }}" />
-                        <input type="hidden" name="youths" value="{{ youths }}" />
-                        <input type="hidden" name="adult_total" value="{{ adult_total }}" />
-                        <input type="hidden" name="youth_total" value="{{ youth_total }}" />
+                        <input type="hidden" name="count" value="{{ count }}" />
                         <input type="hidden" name="total_amount" value="{{ total_amount }}" />
                         <input type="hidden" name="booking_option" value="{{ booking_option }}" />
                         <input type="hidden" name="razorpay_order_id" value="{{ razorpay_order_id }}" />
@@ -109,12 +106,8 @@
                                 <td class="pro__price">{{ booking_option|title }}</td>
                             </tr>
                             <tr>
-                                <td class="pro__title">For {{ adults }} Adult</td>
-                                <td class="pro__price">₹{{ adult_total }}</td>
-                            </tr>
-                            <tr>
-                                <td class="pro__title">For {{ youths }} Youth</td>
-                                <td class="pro__price">₹{{ youth_total }}</td>
+                                <td class="pro__title">Travelers</td>
+                                <td class="pro__price">{{ count }}</td>
                             </tr>
                             <tr>
                                 <td class="pro__title pro__title--total">Total</td>

--- a/templates/emails/admin_order_details.html
+++ b/templates/emails/admin_order_details.html
@@ -26,8 +26,7 @@
         <h3>Booking Summary</h3>
         <table class="details-table">
             <tr><th>Item</th><th>Qty</th><th>Amount</th></tr>
-            <tr><td>Adults</td><td>{{ adults }}</td><td>₹{{ adult_total }}</td></tr>
-            <tr><td>Youths</td><td>{{ youths }}</td><td>₹{{ youth_total }}</td></tr>
+            <tr><td>Travelers</td><td>{{ count }}</td><td>₹{{ total_amount }}</td></tr>
             <tr><td colspan="2"><strong>Total</strong></td><td><strong>₹{{ total_amount }}</strong></td></tr>
         </table>
 

--- a/templates/emails/customer_confirmation.html
+++ b/templates/emails/customer_confirmation.html
@@ -29,8 +29,7 @@
         <h3>Order Summary</h3>
         <table class="details-table">
             <tr><th>Item</th><th>Qty</th><th>Amount</th></tr>
-            <tr><td>Adults</td><td>{{ adults }}</td><td>₹{{ adult_total }}</td></tr>
-            <tr><td>Youths</td><td>{{ youths }}</td><td>₹{{ youth_total }}</td></tr>
+            <tr><td>Travelers</td><td>{{ count }}</td><td>₹{{ total_amount }}</td></tr>
             <tr><td colspan="2"><strong>Total</strong></td><td><strong>₹{{ total_amount }}</strong></td></tr>
         </table>
 

--- a/templates/emails/order_confirmation.html
+++ b/templates/emails/order_confirmation.html
@@ -19,8 +19,7 @@
                 <h3>Booking Summary:</h3>
                 <ul>
                     <li><strong>Booking Option:</strong> {{ booking_option }}</li>
-                    <li><strong>Adults:</strong> {{ adults }} (₹{{ adult_total }})</li>
-                    <li><strong>Youths:</strong> {{ youths }} (₹{{ youth_total }})</li>
+                    <li><strong>Travelers:</strong> {{ count }}</li>
                     <li><strong>Total Amount:</strong> ₹{{ total_amount }}</li>
                 </ul>
 

--- a/templates/tour-detail.html
+++ b/templates/tour-detail.html
@@ -593,20 +593,14 @@
                                     </div>
                                 </div>
                                 <div class="sidebar-two__form__control">
-                                    <label for="adult">Adult:</label>
-                                    <input id="adult" type="number" name="adult" placeholder="Enter Value" value="0"
+                                    <label for="count">No. of Travelers:</label>
+                                    <input id="count" type="number" name="count" placeholder="Enter Value" value="0"
                                         min="0">
                                 </div>
-                                <div class="sidebar-two__form__control">
-                                    <label for="youth">Youth:</label>
-                                    <input id="youth" type="number" name="youth" placeholder="Enter Value" value="0"
-                                        min="0">
-                                    <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
-                                </div>
+                                <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
                                 <input type="hidden" id="checkout" name="checkout">
                                 <div class="sidebar-two__form__control sidebar-two__form__control--two adult-transport">
-                                    <label class="sidebar-two__form__control--title" for="guests">Option for
-                                        Adults:</label>
+                                    <label class="sidebar-two__form__control--title" for="guests">Travel Option:</label>
                                     <ul class="list-unstyled sidebar-two__form__checkbox">
                                         <li>
                                             <input type="checkbox" name="check8" id="check8" data-price="20000">
@@ -629,7 +623,7 @@
                                         </div>
                                     </li>
                                     <li>
-                                        <div class="sidebar-two__form__add">Youth: <span>₹8,000</span></div>
+                                        <div class="sidebar-two__form__add">Per Person: <span>₹8,000</span></div>
                                     </li>
                                 </ul>
 
@@ -653,8 +647,7 @@
 </section><!-- /.tour-listing-details -->
 
 <script>
-    const adultInput = document.getElementById('adult');
-    const youthInput = document.getElementById('youth');
+    const countInput = document.getElementById('count');
     const checkInnova = document.getElementById('check8'); // Innova
     const checkTraveller = document.getElementById('check9'); // Traveller
     const totalAmountDisplay = document.getElementById('totalAmount');
@@ -686,43 +679,39 @@
 
     function calculateTotal() {
         const youthPrice = 8000;
-        let adultPrice = 0;
+        let price = 0;
 
-        if (checkInnova.checked && checkTraveller.checked) {
-            alert("Please select only one transport option.");
-            checkInnova.checked = false;
-            checkTraveller.checked = false;
-            return;
-        } else if (checkInnova.checked) {
-            adultPrice = 20000;
-        } else if (checkTraveller.checked) {
-            adultPrice = 15000;
+        if (bookingOptionField.value === 'youth') {
+            price = youthPrice;
+        } else {
+            if (checkInnova.checked && checkTraveller.checked) {
+                alert("Please select only one transport option.");
+                checkInnova.checked = false;
+                checkTraveller.checked = false;
+                return;
+            } else if (checkInnova.checked) {
+                price = 20000;
+            } else if (checkTraveller.checked) {
+                price = 15000;
+            }
         }
 
-        const adults = parseInt(adultInput.value) || 0;
-        const youths = parseInt(youthInput.value) || 0;
+        const count = parseInt(countInput.value) || 0;
 
-        const adultTotal = adults * adultPrice;
-        const youthTotal = youths * youthPrice;
-
-        const total = adultTotal + youthTotal;
+        const total = count * price;
 
         totalAmountDisplay.textContent = `₹${total.toLocaleString()}`;
         finalAmountInput.value = total;
-        checkoutInput.value = adults + youths;
+        checkoutInput.value = count;
 
         // Store values globally for use on checkout
         window.calculatedValues = {
-            adults,
-            youths,
-            adultTotal,
-            youthTotal,
+            count,
             total,
         };
     }
 
-    adultInput.addEventListener('input', calculateTotal);
-    youthInput.addEventListener('input', calculateTotal);
+    countInput.addEventListener('input', calculateTotal);
     bookingRadios.forEach(r => r.addEventListener('change', updateOption));
     checkInnova.addEventListener('change', () => {
         if (checkInnova.checked) checkTraveller.checked = false;
@@ -740,19 +729,16 @@
 
     goToCheckoutBtn.addEventListener('click', () => {
         const vals = window.calculatedValues || {};
-        const adults = vals.adults || 0;
+        const count = vals.count || 0;
 
-        // ✅ Only require transport if adults > 0
-        if (adults > 0 && !checkInnova.checked && !checkTraveller.checked) {
-            alert("Please select a transport option (Innova or Traveller) for adult bookings.");
+        // ✅ Only require transport if count > 0 for family bookings
+        if (bookingOptionField.value === 'family' && count > 0 && !checkInnova.checked && !checkTraveller.checked) {
+            alert("Please select a transport option (Innova or Traveller) for bookings.");
             return; // Stop navigation
         }
 
         const params = new URLSearchParams({
-            adults: vals.adults || 0,
-            youths: vals.youths || 0,
-            adult_total: vals.adultTotal || 0,
-            youth_total: vals.youthTotal || 0,
+            count: count,
             total_amount: vals.total || 0,
             booking_option: bookingOptionField.value || 'family'
         });

--- a/templates/tour-details.html
+++ b/templates/tour-details.html
@@ -603,20 +603,14 @@
                                     </div>
                                 </div>
                                 <div class="sidebar-two__form__control">
-                                    <label for="adult">Adult:</label>
-                                    <input id="adult" type="number" name="adult" placeholder="Enter Value" value="0"
+                                    <label for="count">No. of Travelers:</label>
+                                    <input id="count" type="number" name="count" placeholder="Enter Value" value="0"
                                         min="0">
                                 </div>
-                                <div class="sidebar-two__form__control">
-                                    <label for="youth">Youth:</label>
-                                    <input id="youth" type="number" name="youth" placeholder="Enter Value" value="0"
-                                        min="0">
-                                    <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
-                                </div>
+                                <small id="child-note" class="form-text text-muted">Each child over 5 years requires a separate seat.</small>
                                 <input type="hidden" id="checkout" name="checkout">
                                 <div class="sidebar-two__form__control sidebar-two__form__control--two adult-transport">
-                                    <label class="sidebar-two__form__control--title" for="guests">Option for
-                                        Adults:</label>
+                                    <label class="sidebar-two__form__control--title" for="guests">Travel Option:</label>
                                     <ul class="list-unstyled sidebar-two__form__checkbox">
                                         <li>
                                             <input type="checkbox" name="check8" id="check8" data-price="20000">
@@ -639,7 +633,7 @@
                                         </div>
                                     </li>
                                     <li>
-                                        <div class="sidebar-two__form__add">Youth: <span>₹8,000</span></div>
+                                        <div class="sidebar-two__form__add">Per Person: <span>₹8,000</span></div>
                                     </li>
                                 </ul>
 
@@ -663,8 +657,7 @@
 </section><!-- /.tour-listing-details -->
 
 <script>
-    const adultInput = document.getElementById('adult');
-    const youthInput = document.getElementById('youth');
+    const countInput = document.getElementById('count');
     const checkInnova = document.getElementById('check8'); // Innova
     const checkTraveller = document.getElementById('check9'); // Traveller
     const totalAmountDisplay = document.getElementById('totalAmount');
@@ -696,43 +689,39 @@
 
     function calculateTotal() {
         const youthPrice = 8000;
-        let adultPrice = 0;
+        let price = 0;
 
-        if (checkInnova.checked && checkTraveller.checked) {
-            alert("Please select only one transport option.");
-            checkInnova.checked = false;
-            checkTraveller.checked = false;
-            return;
-        } else if (checkInnova.checked) {
-            adultPrice = 20000;
-        } else if (checkTraveller.checked) {
-            adultPrice = 15000;
+        if (bookingOptionField.value === 'youth') {
+            price = youthPrice;
+        } else {
+            if (checkInnova.checked && checkTraveller.checked) {
+                alert("Please select only one transport option.");
+                checkInnova.checked = false;
+                checkTraveller.checked = false;
+                return;
+            } else if (checkInnova.checked) {
+                price = 20000;
+            } else if (checkTraveller.checked) {
+                price = 15000;
+            }
         }
 
-        const adults = parseInt(adultInput.value) || 0;
-        const youths = parseInt(youthInput.value) || 0;
+        const count = parseInt(countInput.value) || 0;
 
-        const adultTotal = adults * adultPrice;
-        const youthTotal = youths * youthPrice;
-
-        const total = adultTotal + youthTotal;
+        const total = count * price;
 
         totalAmountDisplay.textContent = `₹${total.toLocaleString()}`;
         finalAmountInput.value = total;
-        checkoutInput.value = adults + youths;
+        checkoutInput.value = count;
 
         // Store values globally for use on checkout
         window.calculatedValues = {
-            adults,
-            youths,
-            adultTotal,
-            youthTotal,
+            count,
             total,
         };
     }
 
-    adultInput.addEventListener('input', calculateTotal);
-    youthInput.addEventListener('input', calculateTotal);
+    countInput.addEventListener('input', calculateTotal);
     bookingRadios.forEach(r => r.addEventListener('change', updateOption));
     checkInnova.addEventListener('change', () => {
         if (checkInnova.checked) checkTraveller.checked = false;
@@ -750,19 +739,16 @@
 
     goToCheckoutBtn.addEventListener('click', () => {
         const vals = window.calculatedValues || {};
-        const adults = vals.adults || 0;
+        const count = vals.count || 0;
 
-        // ✅ Only require transport if adults > 0
-        if (adults > 0 && !checkInnova.checked && !checkTraveller.checked) {
-            alert("Please select a transport option (Innova or Traveller) for adult bookings.");
+        // ✅ Only require transport if count > 0 for family bookings
+        if (bookingOptionField.value === 'family' && count > 0 && !checkInnova.checked && !checkTraveller.checked) {
+            alert("Please select a transport option (Innova or Traveller) for bookings.");
             return; // Stop navigation
         }
 
         const params = new URLSearchParams({
-            adults: vals.adults || 0,
-            youths: vals.youths || 0,
-            adult_total: vals.adultTotal || 0,
-            youth_total: vals.youthTotal || 0,
+            count: count,
             total_amount: vals.total || 0,
             booking_option: bookingOptionField.value || 'family'
         });


### PR DESCRIPTION
## Summary
- remove separate adult/youth fields from tour forms
- compute totals based on a single traveler count
- update checkout and email templates for new count field
- adjust Razorpay views to use `count`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a186d2e8c832d9db61dbeff4113df