### PR TITLE
Validate traveler count before checkout

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -14,9 +14,17 @@ def checkout_view(request):
     total_amount = request.GET.get('total_amount', '0')
     booking_option = request.GET.get('booking_option', 'family')
 
+    try:
+        total_int = int(total_amount)
+    except (TypeError, ValueError):
+        total_int = 0
+
+    if total_int <= 0:
+        return HttpResponseBadRequest('Invalid amount')
+
     client = razorpay.Client(auth=(settings.RAZORPAY_KEY_ID, settings.RAZORPAY_KEY_SECRET))
     order = client.order.create({
-        'amount': int(total_amount) * 100,
+        'amount': total_int * 100,
         'currency': 'INR',
         'payment_capture': 1,
     })

--- a/templates/tour-detail.html
+++ b/templates/tour-detail.html
@@ -657,6 +657,7 @@
     const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
     const transportSection = document.querySelector('.adult-transport');
     const childNote = document.getElementById('child-note');
+    const goToCheckoutBtn = document.getElementById('goToCheckout');
 
     function updateOption() {
         const selected = document.querySelector('input[name="booking_option"]:checked').value;
@@ -703,6 +704,7 @@
         totalAmountDisplay.textContent = `₹${total.toLocaleString()}`;
         finalAmountInput.value = total;
         checkoutInput.value = count;
+        goToCheckoutBtn.disabled = count <= 0;
 
         // Store values globally for use on checkout
         window.calculatedValues = {
@@ -725,11 +727,14 @@
     // Initial run
     updateOption();
 
-    const goToCheckoutBtn = document.getElementById('goToCheckout');
-
     goToCheckoutBtn.addEventListener('click', () => {
         const vals = window.calculatedValues || {};
         const count = vals.count || 0;
+
+        if (count < 1) {
+            alert('Please enter the number of travelers');
+            return;
+        }
 
         // ✅ Only require transport if count > 0 for family bookings
         if (bookingOptionField.value === 'family' && count > 0 && !checkInnova.checked && !checkTraveller.checked) {

--- a/templates/tour-details.html
+++ b/templates/tour-details.html
@@ -667,6 +667,7 @@
     const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
     const transportSection = document.querySelector('.adult-transport');
     const childNote = document.getElementById('child-note');
+    const goToCheckoutBtn = document.getElementById('goToCheckout');
 
     function updateOption() {
         const selected = document.querySelector('input[name="booking_option"]:checked').value;
@@ -713,6 +714,7 @@
         totalAmountDisplay.textContent = `₹${total.toLocaleString()}`;
         finalAmountInput.value = total;
         checkoutInput.value = count;
+        goToCheckoutBtn.disabled = count <= 0;
 
         // Store values globally for use on checkout
         window.calculatedValues = {
@@ -735,11 +737,14 @@
     // Initial run
     updateOption();
 
-    const goToCheckoutBtn = document.getElementById('goToCheckout');
-
     goToCheckoutBtn.addEventListener('click', () => {
         const vals = window.calculatedValues || {};
         const count = vals.count || 0;
+
+        if (count < 1) {
+            alert('Please enter the number of travelers');
+            return;
+        }
 
         // ✅ Only require transport if count > 0 for family bookings
         if (bookingOptionField.value === 'family' && count > 0 && !checkInnova.checked && !checkTraveller.checked) {


### PR DESCRIPTION
## Summary
- prevent creating a Razorpay order when total amount is 0
- disable checkout button if no travellers are entered
- alert users when count is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a4a9218b8832daf7a36ebcdb8a368