### PR TITLE
Add travel option to booking data

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -13,6 +13,7 @@ def checkout_view(request):
     count = request.GET.get('count', '0')
     total_amount = request.GET.get('total_amount', '0')
     booking_option = request.GET.get('booking_option', 'family')
+    travel_option = request.GET.get('travel_option', '')
 
     try:
         total_int = int(total_amount)
@@ -33,6 +34,7 @@ def checkout_view(request):
         'count': count,
         'total_amount': total_amount,
         'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
+        'travel_option': travel_option,
         'razorpay_order_id': order['id'],
         'razorpay_key_id': settings.RAZORPAY_KEY_ID,
     }
@@ -64,6 +66,7 @@ def verify_payment_view(request):
     zip_code = request.POST.get('zip-code')
     email = request.POST.get('email')
     booking_option = request.POST.get('booking_option', 'family')
+    travel_option = request.POST.get('travel_option', '')
     count = request.POST.get('count')
     total_amount = request.POST.get('total_amount')
 
@@ -78,6 +81,7 @@ def verify_payment_view(request):
         'count': count,
         'total_amount': total_amount,
         'booking_option': 'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)',
+        'travel_option': travel_option,
     }).content.decode('utf-8')
     text_content = strip_tags(html_content)
 
@@ -93,6 +97,7 @@ def verify_payment_view(request):
     Email: {email}
     Address: {address}, {city}, {state}, {zip_code}
     Booking Option: {'Family / Individual (Private)' if booking_option == 'family' else 'Youth Group (Shared)'}
+    Travel Option: {travel_option}
     Count: {count}
     Total: ₹{total_amount}
     '''

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -80,6 +80,7 @@
                         <input type="hidden" name="count" value="{{ count }}" />
                         <input type="hidden" name="total_amount" value="{{ total_amount }}" />
                         <input type="hidden" name="booking_option" value="{{ booking_option }}" />
+                        <input type="hidden" name="travel_option" value="{{ travel_option }}" />
                         <input type="hidden" name="razorpay_order_id" value="{{ razorpay_order_id }}" />
                         <button type="button" id="pay-button" class="gotur-btn gotur-btn--base">
                             Pay with Razorpay
@@ -105,6 +106,12 @@
                                 <td class="pro__title">Option</td>
                                 <td class="pro__price">{{ booking_option|title }}</td>
                             </tr>
+                            {% if travel_option %}
+                            <tr>
+                                <td class="pro__title">Travel Option</td>
+                                <td class="pro__price">{{ travel_option }}</td>
+                            </tr>
+                            {% endif %}
                             <tr>
                                 <td class="pro__title">Travelers</td>
                                 <td class="pro__price">{{ count }}</td>

--- a/templates/emails/admin_order_details.html
+++ b/templates/emails/admin_order_details.html
@@ -22,6 +22,7 @@
         <p><strong>Address:</strong> {{ address }}, {{ town_city }}, {{ state }} - {{ zip_code }}</p>
 
         <p><strong>Booking Option:</strong> {{ booking_option }}</p>
+        {% if travel_option %}<p><strong>Travel Option:</strong> {{ travel_option }}</p>{% endif %}
 
         <h3>Booking Summary</h3>
         <table class="details-table">

--- a/templates/emails/customer_confirmation.html
+++ b/templates/emails/customer_confirmation.html
@@ -24,6 +24,7 @@
             <li><strong>Phone:</strong> {{ phone }}</li>
             <li><strong>Address:</strong> {{ address }}, {{ town_city }}, {{ state }} - {{ zip_code }}</li>
             <li><strong>Booking Option:</strong> {{ booking_option }}</li>
+            {% if travel_option %}<li><strong>Travel Option:</strong> {{ travel_option }}</li>{% endif %}
         </ul>
 
         <h3>Order Summary</h3>

--- a/templates/emails/order_confirmation.html
+++ b/templates/emails/order_confirmation.html
@@ -19,6 +19,7 @@
                 <h3>Booking Summary:</h3>
                 <ul>
                     <li><strong>Booking Option:</strong> {{ booking_option }}</li>
+                    {% if travel_option %}<li><strong>Travel Option:</strong> {{ travel_option }}</li>{% endif %}
                     <li><strong>Travelers:</strong> {{ count }}</li>
                     <li><strong>Total Amount:</strong> ₹{{ total_amount }}</li>
                 </ul>

--- a/templates/tour-detail.html
+++ b/templates/tour-detail.html
@@ -654,6 +654,7 @@
     const finalAmountInput = document.getElementById('final_amount');
     const checkoutInput = document.getElementById('checkout');
     const bookingOptionField = document.getElementById('booking_option_field');
+    let travelOption = '';
     const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
     const transportSection = document.querySelector('.adult-transport');
     const childNote = document.getElementById('child-note');
@@ -684,6 +685,7 @@
 
         if (bookingOptionField.value === 'youth') {
             price = youthPrice;
+            travelOption = 'Traveller Bus';
         } else {
             if (checkInnova.checked && checkTraveller.checked) {
                 alert("Please select only one transport option.");
@@ -692,8 +694,12 @@
                 return;
             } else if (checkInnova.checked) {
                 price = 20000;
+                travelOption = 'Innova Car';
             } else if (checkTraveller.checked) {
                 price = 15000;
+                travelOption = 'Traveller Bus';
+            } else {
+                travelOption = '';
             }
         }
 
@@ -710,6 +716,7 @@
         window.calculatedValues = {
             count,
             total,
+            travelOption,
         };
     }
 
@@ -745,7 +752,8 @@
         const params = new URLSearchParams({
             count: count,
             total_amount: vals.total || 0,
-            booking_option: bookingOptionField.value || 'family'
+            booking_option: bookingOptionField.value || 'family',
+            travel_option: vals.travelOption || travelOption
         });
 
         window.location.href = `/checkout/?${params.toString()}`;

--- a/templates/tour-details.html
+++ b/templates/tour-details.html
@@ -664,6 +664,7 @@
     const finalAmountInput = document.getElementById('final_amount');
     const checkoutInput = document.getElementById('checkout');
     const bookingOptionField = document.getElementById('booking_option_field');
+    let travelOption = '';
     const bookingRadios = document.querySelectorAll('input[name="booking_option"]');
     const transportSection = document.querySelector('.adult-transport');
     const childNote = document.getElementById('child-note');
@@ -694,6 +695,7 @@
 
         if (bookingOptionField.value === 'youth') {
             price = youthPrice;
+            travelOption = 'Traveller Bus';
         } else {
             if (checkInnova.checked && checkTraveller.checked) {
                 alert("Please select only one transport option.");
@@ -702,8 +704,12 @@
                 return;
             } else if (checkInnova.checked) {
                 price = 20000;
+                travelOption = 'Innova Car';
             } else if (checkTraveller.checked) {
                 price = 15000;
+                travelOption = 'Traveller Bus';
+            } else {
+                travelOption = '';
             }
         }
 
@@ -720,6 +726,7 @@
         window.calculatedValues = {
             count,
             total,
+            travelOption,
         };
     }
 
@@ -755,7 +762,8 @@
         const params = new URLSearchParams({
             count: count,
             total_amount: vals.total || 0,
-            booking_option: bookingOptionField.value || 'family'
+            booking_option: bookingOptionField.value || 'family',
+            travel_option: vals.travelOption || travelOption
         });
 
         window.location.href = `/checkout/?${params.toString()}`;

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django.urls import reverse
+
+class CheckoutViewTests(TestCase):
+    def test_travel_option_in_context(self):
+        response = self.client.get(reverse('checkout') + '?count=1&total_amount=1000&booking_option=family&travel_option=Innova')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Innova')
+


### PR DESCRIPTION
## Summary
- include travel option in checkout view and verification emails
- render travel option on checkout page
- capture selected travel option when booking a tour
- show travel option in email templates
- test checkout view includes travel option in response

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a5568e2d4832d853c66ea890d6004