### PR TITLE
Show thank you page on payment

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -114,7 +114,8 @@ def verify_payment_view(request):
     )
     admin_email.send()
 
-    return HttpResponse('OK')
+    # After successfully verifying the payment, show the thank you page
+    return render(request, "thank_you.html", {"name": name})
 
 
 # Optional: If you want a dedicated view for thank you page (used in urls.py)

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch
+
+class VerifyPaymentViewTests(TestCase):
+    @patch('holytrail.views.razorpay.Client')
+    def test_payment_success_shows_thank_you_page(self, mock_client):
+        mock_client.return_value.utility.verify_payment_signature.return_value = None
+        data = {
+            'razorpay_order_id': 'order_123',
+            'razorpay_payment_id': 'payment_123',
+            'razorpay_signature': 'sig_123',
+            'first_name': 'John',
+            'phone': '1234567890',
+            'address': '123 Street',
+            'town-city': 'Townsville',
+            'state': 'State',
+            'zip-code': '12345',
+            'email': 'john@example.com',
+            'booking_option': 'family',
+            'travel_option': 'Bus',
+            'count': '2',
+            'total_amount': '1000'
+        }
+        response = self.client.post(reverse('verify_payment'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'thank_you.html')
+        self.assertContains(response, 'John')
+


### PR DESCRIPTION
## Summary
- show thank you page after verifying payment
- add a test for the verify view

## Testing
- `python manage.py test -v 2` *(fails: ImportError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a59092aac832d98693d1c9fc5a4ba