### PR TITLE
Add working login and registration

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,5 @@ app_name = "accounts"
 
 urlpatterns = [
     path("login", views.login_view, name="login"),
+    path("logout", views.logout_view, name="logout"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,5 +1,36 @@
-from django.shortcuts import render
+from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.models import User
+from django.shortcuts import render, redirect
 
-# Create your views here.
 def login_view(request):
-    return render(request, "accounts/login.html")
+    error = ""
+    if request.method == "POST":
+        form_type = request.POST.get("form_type")
+        if form_type == "login":
+            username = request.POST.get("username")
+            password = request.POST.get("password")
+            user = authenticate(request, username=username, password=password)
+            if user is not None:
+                login(request, user)
+                return redirect("home:home")
+            else:
+                error = "Invalid credentials"
+        elif form_type == "register":
+            username = request.POST.get("username")
+            email = request.POST.get("email")
+            password1 = request.POST.get("password1")
+            password2 = request.POST.get("password2")
+            if password1 != password2:
+                error = "Passwords do not match"
+            elif User.objects.filter(username=username).exists():
+                error = "Username already exists"
+            else:
+                user = User.objects.create_user(username=username, email=email, password=password1)
+                login(request, user)
+                return redirect("home:home")
+    return render(request, "accounts/login.html", {"error": error})
+
+
+def logout_view(request):
+    logout(request)
+    return redirect("home:home")

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -61,8 +61,10 @@
                         <!-- /.login-page__top -->
                         <div class="tabs-content">
                             <div class="tabs-content__item tab active-tab" id="login">
-                                <form method="post" action="/admin" class="contact-form-validated form-one">
+                                <form method="post" action="{% url 'accounts:login' %}" class="contact-form-validated form-one">
+                                    <input type="hidden" name="form_type" value="login">
                                     {% csrf_token %}
+                                    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
                                     <div class="login-page__group">
                                         <div class="login-page__input-box">
                                             <i class="icon-email"></i>
@@ -92,20 +94,33 @@
                                 </form>
 
                                 <p class="login-page__form__text">
-                                    don’t have an account?<a href="login.html">register</a>
+                                    don’t have an account?<a href="#register">register</a>
                                 </p>
                             </div>
                             <!-- /.tabs-content__item -->
                             <div class="tabs-content__item tab" id="register">
-                                <form class="contact-form-validated form-one" action="inc/sendemail.php">
+                                <form method="post" action="{% url 'accounts:login' %}" class="contact-form-validated form-one">
+                                    <input type="hidden" name="form_type" value="register">
+                                    {% csrf_token %}
+                                    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
                                     <div class="login-page__group">
                                         <div class="login-page__input-box">
                                             <i class="icon-email"></i>
-                                            <input type="text" name="name" placeholder="your email" />
+                                            <input type="text" name="username" placeholder="username" required />
+                                        </div>
+                                        <div class="login-page__input-box">
+                                            <i class="icon-email"></i>
+                                            <input type="email" name="email" placeholder="email" required />
                                         </div>
                                         <div class="login-page__input-box">
                                             <i class="icon-padlock"></i>
-                                            <input type="password" placeholder="password"
+                                            <input type="password" name="password1" placeholder="password" required
+                                                class="login-page__password" />
+                                            <span class="toggle-password pass-field-icon fa fa-fw fa-eye-slash"></span>
+                                        </div>
+                                        <div class="login-page__input-box">
+                                            <i class="icon-padlock"></i>
+                                            <input type="password" name="password2" placeholder="confirm password" required
                                                 class="login-page__password" />
                                             <span class="toggle-password pass-field-icon fa fa-fw fa-eye-slash"></span>
                                         </div>
@@ -127,7 +142,7 @@
                                     </div>
                                 </form>
                                 <p class="login-page__form__text">
-                                    don’t have an account?<a href="login.html">log in</a>
+                                    Already have an account?<a href="#login">log in</a>
                                 </p>
                             </div>
                             <!-- /.tabs-content__item -->

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+class AccountsTests(TestCase):
+    def test_login_page_loads(self):
+        response = self.client.get(reverse('accounts:login'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_registration(self):
+        data = {
+            'form_type': 'register',
+            'username': 'newuser',
+            'email': 'new@example.com',
+            'password1': 'pass12345',
+            'password2': 'pass12345'
+        }
+        response = self.client.post(reverse('accounts:login'), data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(User.objects.filter(username='newuser').exists())
+
+    def test_user_login(self):
+        User.objects.create_user(username='tester', password='pass12345')
+        data = {
+            'form_type': 'login',
+            'username': 'tester',
+            'password': 'pass12345'
+        }
+        response = self.client.post(reverse('accounts:login'), data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(int(self.client.session['_auth_user_id']), User.objects.get(username='tester').id)


### PR DESCRIPTION
## Summary
- implement basic login/registration logic in `accounts.views`
- expose logout path in `accounts.urls`
- hook login and register forms to backend
- add tests for authentication flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a615e9bc4832da15f5a3593846546