### PR TITLE
Require login for checkout and payment

### DIFF
--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -6,8 +6,10 @@ from django.shortcuts import render
 from django.utils.html import strip_tags
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.contrib.auth.decorators import login_required
 
     
+@login_required(login_url='accounts:login')
 def checkout_view(request):
     # Always prepare a Razorpay order for the given amount
     count = request.GET.get('count', '0')
@@ -42,6 +44,7 @@ def checkout_view(request):
 
 
 @csrf_exempt
+@login_required(login_url='accounts:login')
 def verify_payment_view(request):
     if request.method != 'POST':
         return HttpResponseBadRequest('Invalid request')

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,9 +1,21 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.contrib.auth.models import User
+
 
 class CheckoutViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass12345")
+
     def test_travel_option_in_context(self):
+        self.client.login(username="tester", password="pass12345")
         response = self.client.get(reverse('checkout') + '?count=1&total_amount=1000&booking_option=family&travel_option=Innova')
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Innova')
+
+    def test_redirect_if_not_logged_in(self):
+        url = reverse('checkout') + '?count=1&total_amount=1000&booking_option=family&travel_option=Bus'
+        response = self.client.get(url)
+        login_url = reverse('accounts:login') + '?next=' + url
+        self.assertRedirects(response, login_url)
 

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,10 +1,20 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.contrib.auth.models import User
 from unittest.mock import patch
 
 class VerifyPaymentViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass12345")
+
+    def test_login_required(self):
+        response = self.client.post(reverse('verify_payment'))
+        login_url = reverse('accounts:login') + '?next=' + reverse('verify_payment')
+        self.assertRedirects(response, login_url)
+
     @patch('holytrail.views.razorpay.Client')
     def test_payment_success_shows_thank_you_page(self, mock_client):
+        self.client.login(username="tester", password="pass12345")
         mock_client.return_value.utility.verify_payment_signature.return_value = None
         data = {
             'razorpay_order_id': 'order_123',


### PR DESCRIPTION
## Summary
- secure checkout and verify_payment views with `login_required`
- update checkout tests to create a user and assert login redirect
- update payment tests to require login and test redirect

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688c2e5fb858832d8dfc34c2e136cb20