### PR TITLE
Update requirements and remove old social auth URL

### DIFF
--- a/holytrail/urls.py
+++ b/holytrail/urls.py
@@ -33,7 +33,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path("", include("home.urls")),
     path("accounts/", include("accounts.urls")),
-    path('auth/', include('social_django.urls', namespace='social')),
     path("tour/", include("tour.urls")),
     path('blogs/', include('blog.urls', namespace='blog')),
     path("checkout/", views.checkout_view, name="checkout"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django>=5.2
 jazzmin
 django-ckeditor-5
 razorpay
+django-allauth
+Pillow


### PR DESCRIPTION
## Summary
- add authentication dependencies to `requirements.txt`
- drop unused `social_django` URL entry

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c842b5df8832db2b8001f3702fb3f