### PR TITLE
Update Google OAuth settings

### DIFF
--- a/holytrail/settings/base.py
+++ b/holytrail/settings/base.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     # Third-party apps (like CKEditor)
     'django_ckeditor_5',
 
@@ -62,14 +63,24 @@ INSTALLED_APPS = [
 
 ]
 
+# Site framework configuration
+SITE_ID = 1
+
 # Authentication backends
 AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',  # Use only allauth backend
 )
 
-# Google OAuth credentials
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("GOOGLE_ID")
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("GOOGLE_key")
+# Google OAuth configuration for django-allauth
+SOCIALACCOUNT_PROVIDERS = {
+    "google": {
+        "APP": {
+            "client_id": os.environ.get("GOOGLE_ID", ""),
+            "secret": os.environ.get("GOOGLE_KEY", ""),
+            "key": "",
+        }
+    }
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/holytrail/settings/production.py
+++ b/holytrail/settings/production.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     # Third-party apps (like CKEditor)
     'django_ckeditor_5',
     
@@ -58,14 +59,24 @@ INSTALLED_APPS = [
 
 ]
 
+# Site framework configuration
+SITE_ID = 1
+
 # Authentication backends
 AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',  # Use only allauth backend
 )
 
-# Google OAuth credentials
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("GOOGLE_ID")
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("GOOGLE_key")
+# Google OAuth configuration for django-allauth
+SOCIALACCOUNT_PROVIDERS = {
+    "google": {
+        "APP": {
+            "client_id": os.environ.get("GOOGLE_ID", ""),
+            "secret": os.environ.get("GOOGLE_KEY", ""),
+            "key": "",
+        }
+    }
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
## Summary
- enable the Django sites framework
- configure Google login via django-allauth

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c8548537c832d8d910f87ded02370