### PR TITLE
Remove unused social auth link

### DIFF
--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -59,9 +59,7 @@
                             <!-- /.login-page__top__btn -->
                         </div>
                         <!-- /.login-page__top -->
-                         <a href="{% provider_login_url 'google' %}">Sign in with Google</a><br>
-                        <a href="{% url 'social:begin' 'google' %}">Sign in with Google</a>
-
+                        <a href="{% provider_login_url 'google' %}">Sign in with Google</a><br>
                         <div class="tabs-content">
                             <div class="tabs-content__item tab active-tab" id="login">
                                 <form method="post" action="{% url 'accounts:login' %}" class="form-one">


### PR DESCRIPTION
## Summary
- remove unused Google social auth link from login page

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c87572758832da3217e384a4a0b2a