### PR TITLE
Fix duplicate import

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,4 +1,3 @@
-from django.urls import path
 from django.urls import path, include
 
 from . import views


### PR DESCRIPTION
## Summary
- remove the redundant `path` import in `accounts/urls.py`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688c884d6214832db3e4106ef7b2c5ab