### PR TITLE
Send welcome email on registration

### DIFF
--- a/templates/emails/welcome_email.html
+++ b/templates/emails/welcome_email.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome to Holytrail</title>
+</head>
+<body>
+    <p>Dear {{ username }},</p>
+    <p>Thank you for registering at Holytrail.</p>
+    <p>Your account details are as follows:</p>
+    <ul>
+        <li><strong>Email:</strong> {{ email }}</li>
+        <li><strong>Password:</strong> {{ password }}</li>
+    </ul>
+    <p>Hare Krishna,<br>Team Holytrail</p>
+</body>
+</html>

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.core import mail
 
 class AccountsTests(TestCase):
     def test_login_page_loads(self):
@@ -29,3 +30,15 @@ class AccountsTests(TestCase):
         response = self.client.post(reverse('accounts:login'), data)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(int(self.client.session['_auth_user_id']), User.objects.get(username='tester').id)
+
+    def test_registration_sends_welcome_email(self):
+        data = {
+            'form_type': 'register',
+            'username': 'emailuser',
+            'email': 'email@example.com',
+            'password1': 'pass12345',
+            'password2': 'pass12345'
+        }
+        self.client.post(reverse('accounts:login'), data)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, 'Welcome to Holytrail')


### PR DESCRIPTION
## Summary
- notify users via email after registration
- add welcome email template
- test that registration triggers welcome email

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c999fb0b4832d85b6168e61605a06