### PR TITLE
Add login/logout links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -213,6 +213,13 @@
                                 <li>
                                     <a href="contact">Contact</a>
                                 </li>
+                                <li>
+                                    {% if user.is_authenticated %}
+                                    <a href="{% url 'accounts:logout' %}">Logout</a>
+                                    {% else %}
+                                    <a href="{% url 'accounts:login' %}">Login</a>
+                                    {% endif %}
+                                </li>
                             </ul>
                         </nav><!-- /.main-header__nav -->
                         <div class="main-header__info">


### PR DESCRIPTION
## Summary
- show login and logout options in the navigation bar

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c9c1201ec832d840d688da3120007