### PR TITLE
Add duplicate email check with tests

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -40,6 +40,8 @@ def login_view(request):
                 error = "Passwords do not match"
             elif User.objects.filter(username=username).exists():
                 error = "Username already exists"
+            elif User.objects.filter(email=email).exists():
+                error = "Email already exists"
             else:
                 user = User.objects.create_user(
                     username=username,

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -59,3 +59,17 @@ class AccountsTests(TestCase):
         self.assertRedirects(response, reverse('home:home'))
         user.refresh_from_db()
         self.assertTrue(user.is_active)
+
+    def test_registration_duplicate_email(self):
+        User.objects.create_user(username='existing', email='dup@example.com', password='pass12345')
+        data = {
+            'form_type': 'register',
+            'username': 'otheruser',
+            'email': 'dup@example.com',
+            'password1': 'pass12345',
+            'password2': 'pass12345'
+        }
+        response = self.client.post(reverse('accounts:login'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Email already exists')
+        self.assertEqual(User.objects.filter(email='dup@example.com').count(), 1)


### PR DESCRIPTION
## Summary
- check for duplicate emails in registration
- test registration fails when email is already used

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688d06f6c5f4832d844104646137d9a9