### PR TITLE
Split login and registration pages

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,6 +6,7 @@ app_name = "accounts"
 
 urlpatterns = [
     path("login", views.login_view, name="login"),
+    path("register", views.register_view, name="register"),
     path("logout", views.logout_view, name="logout"),
     path("verify", views.verify_email_view, name="verify_email"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -21,56 +21,59 @@ def social_account_login(sender, request, sociallogin, **kwargs):
 def login_view(request):
     error = ""
     if request.method == "POST":
-        form_type = request.POST.get("form_type")
-        if form_type == "login":
-            username = request.POST.get("username")
-            password = request.POST.get("password")
-            user = authenticate(request, username=username, password=password)
-            if user is not None:
-                login(request, user)
-                return redirect("home:home")
-            else:
-                error = "Invalid credentials"
-        elif form_type == "register":
-            username = request.POST.get("username")
-            email = request.POST.get("email")
-            password1 = request.POST.get("password1")
-            password2 = request.POST.get("password2")
-            if password1 != password2:
-                error = "Passwords do not match"
-            elif User.objects.filter(username=username).exists():
-                error = "Username already exists"
-            elif User.objects.filter(email=email).exists():
-                error = "Email already exists"
-            else:
-                user = User.objects.create_user(
-                    username=username,
-                    email=email,
-                    password=password1,
-                    is_active=False,
-                )
-
-                otp_code = get_random_string(6, allowed_chars="0123456789")
-                EmailOTP.objects.create(user=user, code=otp_code)
-
-                html_content = render_to_string(
-                    "emails/otp_email.html",
-                    {"username": username, "code": otp_code},
-                )
-                text_content = strip_tags(html_content)
-                subject = "Verify your email"
-                email_message = EmailMultiAlternatives(
-                    subject,
-                    text_content,
-                    settings.DEFAULT_FROM_EMAIL,
-                    [email],
-                )
-                email_message.attach_alternative(html_content, "text/html")
-                email_message.send()
-
-                request.session["otp_user_id"] = user.id
-                return redirect("accounts:verify_email")
+        username = request.POST.get("username")
+        password = request.POST.get("password")
+        user = authenticate(request, username=username, password=password)
+        if user is not None:
+            login(request, user)
+            return redirect("home:home")
+        else:
+            error = "Invalid credentials"
     return render(request, "accounts/login.html", {"error": error})
+
+
+def register_view(request):
+    error = ""
+    if request.method == "POST":
+        username = request.POST.get("username")
+        email = request.POST.get("email")
+        password1 = request.POST.get("password1")
+        password2 = request.POST.get("password2")
+        if password1 != password2:
+            error = "Passwords do not match"
+        elif User.objects.filter(username=username).exists():
+            error = "Username already exists"
+        elif User.objects.filter(email=email).exists():
+            error = "Email already exists"
+        else:
+            user = User.objects.create_user(
+                username=username,
+                email=email,
+                password=password1,
+                is_active=False,
+            )
+
+            otp_code = get_random_string(6, allowed_chars="0123456789")
+            EmailOTP.objects.create(user=user, code=otp_code)
+
+            html_content = render_to_string(
+                "emails/otp_email.html",
+                {"username": username, "code": otp_code},
+            )
+            text_content = strip_tags(html_content)
+            subject = "Verify your email"
+            email_message = EmailMultiAlternatives(
+                subject,
+                text_content,
+                settings.DEFAULT_FROM_EMAIL,
+                [email],
+            )
+            email_message.attach_alternative(html_content, "text/html")
+            email_message.send()
+
+            request.session["otp_user_id"] = user.id
+            return redirect("accounts:verify_email")
+    return render(request, "accounts/register.html", {"error": error})
 
 
 def logout_view(request):

--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -1,18 +1,17 @@
 {% extends 'base.html' %}
 {% load static %}
-{% block doc_title %} Login {% endblock %}
+{% block doc_title %} Register {% endblock %}
 {% block content %}
-{% load socialaccount %}
 
 <section class="page-header">
     <div class="page-header__bg" style="background-image: url({% static 'images/backgrounds/page-header-bg-1-1.jpg' %});"></div>
     <!-- /.page-header__bg -->
     <div class="container">
         <div class="page-header__content">
-            <h2 class="page-header__title bw-split-in-right">Sign In</h2>
+            <h2 class="page-header__title bw-split-in-right">Sign Up</h2>
             <ul class="gotur-breadcrumb list-unstyled">
                 <li><a href="/">Home</a></li>
-                <li><span>Sign In</span></li>
+                <li><span>Sign Up</span></li>
             </ul>
             <!-- /.thm-breadcrumb list-unstyled -->
         </div>
@@ -42,14 +41,14 @@
                                 <h2 class="login-page__top__section-title">welcome</h2>
                                 <!-- /.login-page__top__section-title -->
                                 <p class="login-page__top__section-subtitle">
-                                    sign in your account
+                                    create your account
                                 </p>
                                 <!-- /.login-page__top__section-subtitle -->
                             </div>
                             <!-- /.login-page__top__left -->
                         </div>
                         <!-- /.login-page__top -->
-                        <form method="post" action="{% url 'accounts:login' %}" class="form-one">
+                        <form method="post" action="{% url 'accounts:register' %}" class="form-one">
                             {% csrf_token %}
                             {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
                             <div class="login-page__group">
@@ -58,29 +57,35 @@
                                     <input type="text" name="username" placeholder="username" required />
                                 </div>
                                 <div class="login-page__input-box">
+                                    <i class="icon-email"></i>
+                                    <input type="email" name="email" placeholder="email" required />
+                                </div>
+                                <div class="login-page__input-box">
                                     <i class="icon-padlock"></i>
-                                    <input type="password" name="password" placeholder="password" required class="login-page__password" />
+                                    <input type="password" name="password1" placeholder="password" required class="login-page__password" />
+                                    <span class="toggle-password pass-field-icon fa fa-fw fa-eye-slash"></span>
+                                </div>
+                                <div class="login-page__input-box">
+                                    <i class="icon-padlock"></i>
+                                    <input type="password" name="password2" placeholder="confirm password" required class="login-page__password" />
                                     <span class="toggle-password pass-field-icon fa fa-fw fa-eye-slash"></span>
                                 </div>
                                 <div class="login-page__input-box login-page__input-box--bottom">
                                     <div class="login-page__input-box__inner">
-                                        <input id="remember-policy2" name="remember_me" type="checkbox" />
-                                        <label class="remember-policy" for="remember-policy2">remember
-                                            me</label>
+                                        <input id="remember-policy" class="login-page__input-box__toggle" type="checkbox" />
+                                        <label class="remember-policy" for="remember-policy">remember me</label>
                                     </div>
-                                    <a href="" class="login-page__form__forgot">forgot
-                                        password?</a>
+                                    <a href="#" class="login-page__form__forgot">forgot password?</a>
                                 </div>
                                 <div class="login-page__input-box">
                                     <div class="login-page__input-box__btn">
-                                        <button type="submit" class="gotur-btn">log in</button>
+                                        <button type="submit" class="gotur-btn">register</button>
                                     </div>
                                 </div>
                             </div>
                         </form>
-
                         <p class="login-page__form__text">
-                            don’t have an account?<a href="{% url 'accounts:register' %}">register</a>
+                            Already have an account?<a href="{% url 'accounts:login' %}">log in</a>
                         </p>
                     </div>
                 </div>

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -10,13 +10,12 @@ class AccountsTests(TestCase):
 
     def test_user_registration(self):
         data = {
-            'form_type': 'register',
             'username': 'newuser',
             'email': 'new@example.com',
             'password1': 'pass12345',
             'password2': 'pass12345'
         }
-        response = self.client.post(reverse('accounts:login'), data)
+        response = self.client.post(reverse('accounts:register'), data)
         self.assertRedirects(response, reverse('accounts:verify_email'))
         user = User.objects.get(username='newuser')
         self.assertFalse(user.is_active)
@@ -24,7 +23,6 @@ class AccountsTests(TestCase):
     def test_user_login(self):
         User.objects.create_user(username='tester', password='pass12345')
         data = {
-            'form_type': 'login',
             'username': 'tester',
             'password': 'pass12345'
         }
@@ -34,25 +32,23 @@ class AccountsTests(TestCase):
 
     def test_registration_sends_otp_email(self):
         data = {
-            'form_type': 'register',
             'username': 'emailuser',
             'email': 'email@example.com',
             'password1': 'pass12345',
             'password2': 'pass12345'
         }
-        self.client.post(reverse('accounts:login'), data)
+        self.client.post(reverse('accounts:register'), data)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, 'Verify your email')
 
     def test_email_verification(self):
         data = {
-            'form_type': 'register',
             'username': 'verifyuser',
             'email': 'verify@example.com',
             'password1': 'pass12345',
             'password2': 'pass12345'
         }
-        self.client.post(reverse('accounts:login'), data)
+        self.client.post(reverse('accounts:register'), data)
         user = User.objects.get(username='verifyuser')
         otp = user.email_otps.first()
         response = self.client.post(reverse('accounts:verify_email'), {'code': otp.code})
@@ -63,13 +59,12 @@ class AccountsTests(TestCase):
     def test_registration_duplicate_email(self):
         User.objects.create_user(username='existing', email='dup@example.com', password='pass12345')
         data = {
-            'form_type': 'register',
             'username': 'otheruser',
             'email': 'dup@example.com',
             'password1': 'pass12345',
             'password2': 'pass12345'
         }
-        response = self.client.post(reverse('accounts:login'), data)
+        response = self.client.post(reverse('accounts:register'), data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Email already exists')
         self.assertEqual(User.objects.filter(email='dup@example.com').count(), 1)


### PR DESCRIPTION
## Summary
- separate login and registration templates
- add `register_view` and URL
- update tests for new registration endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688d08bbe01c832d841a9974dd7c025f