### PR TITLE
Add email verification check for bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Set these variables in your deployment environment to configure email notificati
 New users now receive a one-time password (OTP) when registering. They must
 visit `/account/verify` and enter the code from the email to activate their
 account.
+Users must verify their account before booking a tour. If the original OTP email
+is lost, click **Resend OTP** on the verification page to receive a new code.
 Existing users who forget their password can request a reset OTP by visiting
 `/account/forgot-password` and then set a new password after verifying the code.
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("register", views.register_view, name="register"),
     path("logout", views.logout_view, name="logout"),
     path("verify", views.verify_email_view, name="verify_email"),
+    path("verify/resend", views.resend_otp_view, name="resend_otp"),
     path("forgot-password", views.forgot_password_view, name="forgot_password"),
     path("reset/verify", views.verify_reset_otp_view, name="verify_reset_otp"),
     path("reset/password", views.reset_password_view, name="reset_password"),

--- a/holytrail/views.py
+++ b/holytrail/views.py
@@ -2,7 +2,7 @@ import os
 import razorpay
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.utils.html import strip_tags
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -11,6 +11,9 @@ from django.contrib.auth.decorators import login_required
     
 @login_required(login_url='accounts:login')
 def checkout_view(request):
+    if not request.user.is_active:
+        request.session['otp_user_id'] = request.user.id
+        return redirect('accounts:verify_email')
     # Always prepare a Razorpay order for the given amount
     count = request.GET.get('count', '0')
     total_amount = request.GET.get('total_amount', '0')
@@ -46,6 +49,9 @@ def checkout_view(request):
 @csrf_exempt
 @login_required(login_url='accounts:login')
 def verify_payment_view(request):
+    if not request.user.is_active:
+        request.session['otp_user_id'] = request.user.id
+        return redirect('accounts:verify_email')
     if request.method != 'POST':
         return HttpResponseBadRequest('Invalid request')
 

--- a/templates/accounts/verify_email.html
+++ b/templates/accounts/verify_email.html
@@ -16,6 +16,10 @@
                 </div>
             </div>
         </form>
+        <form method="post" action="{% url 'accounts:resend_otp' %}">
+            {% csrf_token %}
+            <button type="submit" class="gotur-btn">Resend OTP</button>
+        </form>
     </div>
 </section>
 {% endblock %}

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -56,6 +56,18 @@ class AccountsTests(TestCase):
         user.refresh_from_db()
         self.assertTrue(user.is_active)
 
+    def test_resend_otp(self):
+        data = {
+            'username': 'resenduser',
+            'email': 'resend@example.com',
+            'password1': 'pass12345',
+            'password2': 'pass12345'
+        }
+        self.client.post(reverse('accounts:register'), data)
+        response = self.client.post(reverse('accounts:resend_otp'))
+        self.assertRedirects(response, reverse('accounts:verify_email'))
+        self.assertEqual(len(mail.outbox), 2)
+
     def test_registration_duplicate_email(self):
         User.objects.create_user(username='existing', email='dup@example.com', password='pass12345')
         data = {

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -19,3 +19,12 @@ class CheckoutViewTests(TestCase):
         login_url = reverse('accounts:login') + '?next=' + url
         self.assertRedirects(response, login_url)
 
+    def test_redirect_if_not_verified(self):
+        unverified = User.objects.create_user(
+            username="unverified", password="pass12345", is_active=False
+        )
+        self.client.force_login(unverified)
+        url = reverse('checkout') + '?count=1&total_amount=1000&booking_option=family&travel_option=Bus'
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse('accounts:verify_email'))
+

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -12,6 +12,12 @@ class VerifyPaymentViewTests(TestCase):
         login_url = reverse('accounts:login') + '?next=' + reverse('verify_payment')
         self.assertRedirects(response, login_url)
 
+    def test_redirect_if_not_verified(self):
+        unverified = User.objects.create_user(username='nov', password='pass12345', is_active=False)
+        self.client.force_login(unverified)
+        response = self.client.post(reverse('verify_payment'))
+        self.assertRedirects(response, reverse('accounts:verify_email'))
+
     @patch('holytrail.views.razorpay.Client')
     def test_payment_success_shows_thank_you_page(self, mock_client):
         self.client.login(username="tester", password="pass12345")


### PR DESCRIPTION
## Summary
- require verified accounts when booking or paying
- allow users to resend OTP codes
- display Resend OTP button on the verification page
- update docs
- test new behaviours

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688d15d0c560832d8255a92ab84eb6fc