### PR TITLE
Fix unverified login redirect

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -28,6 +28,10 @@ def login_view(request):
             login(request, user)
             return redirect("home:home")
         else:
+            user_obj = User.objects.filter(username=username).first()
+            if user_obj and user_obj.check_password(password) and not user_obj.is_active:
+                request.session["otp_user_id"] = user_obj.id
+                return redirect("accounts:verify_email")
             error = "Invalid credentials"
     return render(request, "accounts/login.html", {"error": error})
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -30,6 +30,17 @@ class AccountsTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(int(self.client.session['_auth_user_id']), User.objects.get(username='tester').id)
 
+    def test_unverified_user_login_redirects_to_verify(self):
+        user = User.objects.create_user(username='inactive', password='pass12345', is_active=False)
+        data = {
+            'username': 'inactive',
+            'password': 'pass12345'
+        }
+        response = self.client.post(reverse('accounts:login'), data)
+        self.assertRedirects(response, reverse('accounts:verify_email'))
+        self.assertEqual(self.client.session.get('otp_user_id'), user.id)
+        self.assertIsNone(self.client.session.get('_auth_user_id'))
+
     def test_registration_sends_otp_email(self):
         data = {
             'username': 'emailuser',


### PR DESCRIPTION
## Summary
- send unverified users to the OTP verification page when attempting to log in
- test new behaviour with redirect for inactive accounts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688d19577e98832dbc14cec43ef2881c