### PR TITLE
Send welcome email after registration

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -75,6 +75,24 @@ def register_view(request):
             email_message.attach_alternative(html_content, "text/html")
             email_message.send()
 
+            welcome_html = render_to_string(
+                "emails/welcome_email.html",
+                {
+                    "username": username,
+                    "email": email,
+                    "password": password1,
+                },
+            )
+            welcome_text = strip_tags(welcome_html)
+            welcome_email = EmailMultiAlternatives(
+                "Welcome to Holytrail",
+                welcome_text,
+                settings.DEFAULT_FROM_EMAIL,
+                [email],
+            )
+            welcome_email.attach_alternative(welcome_html, "text/html")
+            welcome_email.send()
+
             request.session["otp_user_id"] = user.id
             return redirect("accounts:verify_email")
     return render(request, "accounts/register.html", {"error": error})

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -49,8 +49,9 @@ class AccountsTests(TestCase):
             'password2': 'pass12345'
         }
         self.client.post(reverse('accounts:register'), data)
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(mail.outbox[0].subject, 'Verify your email')
+        self.assertEqual(mail.outbox[1].subject, 'Welcome to Holytrail')
 
     def test_email_verification(self):
         data = {
@@ -77,7 +78,7 @@ class AccountsTests(TestCase):
         self.client.post(reverse('accounts:register'), data)
         response = self.client.post(reverse('accounts:resend_otp'))
         self.assertRedirects(response, reverse('accounts:verify_email'))
-        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(len(mail.outbox), 3)
 
     def test_registration_duplicate_email(self):
         User.objects.create_user(username='existing', email='dup@example.com', password='pass12345')


### PR DESCRIPTION
## Summary
- notify new sign ups with a welcome email
- update tests for new welcome email

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688d1ef25be0832dbc23d8c98a3b662a