### PR TITLE
Add user dashboard view and navigation

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("login", views.login_view, name="login"),
     path("register", views.register_view, name="register"),
     path("logout", views.logout_view, name="logout"),
+    path("dashboard", views.dashboard_view, name="dashboard"),
     path("verify", views.verify_email_view, name="verify_email"),
     path("verify/resend", views.resend_otp_view, name="resend_otp"),
     path("forgot-password", views.forgot_password_view, name="forgot_password"),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.shortcuts import render, redirect
 from allauth.socialaccount.signals import pre_social_login
@@ -10,6 +11,7 @@ from django.conf import settings
 from django.utils.crypto import get_random_string
 
 from .models import EmailOTP, PasswordResetOTP
+from tour.models import Order
 
 @receiver(pre_social_login)
 def social_account_login(sender, request, sociallogin, **kwargs):
@@ -245,3 +247,14 @@ def reset_password_view(request):
             request.session.pop("password_reset_verified", None)
             return redirect("accounts:login")
     return render(request, "accounts/reset_password.html", {"error": error})
+
+
+@login_required
+def dashboard_view(request):
+    user = request.user
+    orders = Order.objects.filter(user=user)
+    return render(
+        request,
+        "accounts/dashboard.html",
+        {"user": user, "orders": orders},
+    )

--- a/templates/accounts/dashboard.html
+++ b/templates/accounts/dashboard.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block doc_title %} Dashboard {% endblock %}
+{% block content %}
+<section class="page-header">
+    <div class="page-header__bg" style="background-image: url({% static 'images/backgrounds/page-header-bg-1-1.jpg' %});"></div>
+    <div class="container">
+        <div class="page-header__content">
+            <h2 class="page-header__title bw-split-in-right">Dashboard</h2>
+            <ul class="gotur-breadcrumb list-unstyled">
+                <li><a href="/">Home</a></li>
+                <li><span>Dashboard</span></li>
+            </ul>
+        </div>
+    </div>
+</section>
+
+<section class="section-space">
+    <div class="container">
+        <h3>Profile</h3>
+        <p><strong>Username:</strong> {{ user.username }}</p>
+        <p><strong>Email:</strong> {{ user.email }}</p>
+
+        <h3>Your Orders</h3>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Booking Option</th>
+                    <th>Travel Option</th>
+                    <th>Total Amount</th>
+                    <th>Created</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for order in orders %}
+                <tr>
+                    <td>{{ order.id }}</td>
+                    <td>{{ order.get_booking_option_display }}</td>
+                    <td>{{ order.travel_option }}</td>
+                    <td>{{ order.total_amount }}</td>
+                    <td>{{ order.created_at }}</td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="5">No orders found.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -213,13 +213,18 @@
                                 <li>
                                     <a href="contact">Contact</a>
                                 </li>
+                                {% if user.is_authenticated %}
                                 <li>
-                                    {% if user.is_authenticated %}
-                                    <a href="{% url 'accounts:logout' %}">Logout</a>
-                                    {% else %}
-                                    <a href="{% url 'accounts:login' %}">Login</a>
-                                    {% endif %}
+                                    <a href="{% url 'accounts:dashboard' %}">Dashboard</a>
                                 </li>
+                                <li>
+                                    <a href="{% url 'accounts:logout' %}">Logout</a>
+                                </li>
+                                {% else %}
+                                <li>
+                                    <a href="{% url 'accounts:login' %}">Login</a>
+                                </li>
+                                {% endif %}
                             </ul>
                         </nav><!-- /.main-header__nav -->
                         <div class="main-header__info">


### PR DESCRIPTION
## Summary
- add login-protected dashboard view pulling current user's orders
- expose dashboard route and link from main navigation
- implement dashboard template to show user profile info and orders

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*

------
https://chatgpt.com/codex/tasks/task_e_6894c9aa97b8832d853183e8c9138d4f