### PR TITLE
Add subscription model with admin integration

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Subscription
+
+
+@admin.register(Subscription)
+class SubscriptionAdmin(admin.ModelAdmin):
+    list_display = ("user", "start_date", "end_date", "active")
+    list_filter = ("active",)
+    search_fields = ("user__username", "user__email")

--- a/accounts/migrations/0003_subscription.py
+++ b/accounts/migrations/0003_subscription.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounts', '0002_passwordresetotp'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Subscription',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('start_date', models.DateField()),
+                ('end_date', models.DateField(blank=True, null=True)),
+                ('active', models.BooleanField(default=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='subscriptions', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -32,3 +32,19 @@ class PasswordResetOTP(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"{self.user.username} - {self.code}"
+
+
+class Subscription(models.Model):
+    """Store subscription details for a user."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="subscriptions",
+    )
+    start_date = models.DateField()
+    end_date = models.DateField(null=True, blank=True)
+    active = models.BooleanField(default=True)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.user.username} subscription"


### PR DESCRIPTION
## Summary
- add Subscription model with lifecycle fields
- expose Subscription in Django admin
- create migration for Subscription

## Testing
- `python manage.py makemigrations accounts` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a001e0f628832da0b420ba6ca0c4ee