### PR TITLE
Add Razorpay subscription flow

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     path("forgot-password", views.forgot_password_view, name="forgot_password"),
     path("reset/verify", views.verify_reset_otp_view, name="verify_reset_otp"),
     path("reset/password", views.reset_password_view, name="reset_password"),
+    path("subscribe", views.subscribe_view, name="subscribe"),
+    path("subscribe/verify", views.verify_subscription_payment_view, name="verify_subscription_payment"),
 ]

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Subscribe</title>
+</head>
+<body>
+    <h1>Holytrail Subscription</h1>
+    <form id="payment-form" method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="razorpay_order_id" value="{{ razorpay_order_id }}">
+        <button id="pay-button" type="button">Pay ₹9999</button>
+    </form>
+    <script src="https://checkout.razorpay.com/v1/checkout.js"></script>
+    <script>
+        var options = {
+            key: '{{ razorpay_key_id }}',
+            order_id: '{{ razorpay_order_id }}',
+            name: 'Holytrail Subscription',
+            description: 'Annual subscription',
+            handler: function (response) {
+                var form = document.getElementById('payment-form');
+                form.action = '{% url "accounts:verify_subscription_payment" %}';
+                var pid = document.createElement('input');
+                pid.type = 'hidden';
+                pid.name = 'razorpay_payment_id';
+                pid.value = response.razorpay_payment_id;
+                form.appendChild(pid);
+                var sig = document.createElement('input');
+                sig.type = 'hidden';
+                sig.name = 'razorpay_signature';
+                sig.value = response.razorpay_signature;
+                form.appendChild(sig);
+                form.submit();
+            }
+        };
+        document.getElementById('pay-button').onclick = function(e){
+            var rzp = new Razorpay(options);
+            rzp.open();
+            e.preventDefault();
+        };
+    </script>
+</body>
+</html>

--- a/templates/subscription_success.html
+++ b/templates/subscription_success.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Subscription Successful</title>
+</head>
+<body>
+    <h1>Thank you for subscribing!</h1>
+    <p>Your subscription payment was successful.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add subscription checkout and verification views using Razorpay
- Wire up URLs for subscription payment flow
- Provide minimal templates for subscription checkout and success confirmation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a004e90414832db46c4f8e1dc1508b