### PR TITLE
Apply subscription discount for checkout and verification

### DIFF
--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -73,6 +73,7 @@
                         </div>
                         <input type="hidden" name="count" value="{{ count }}" />
                         <input type="hidden" name="total_amount" value="{{ total_amount }}" />
+                        <input type="hidden" name="original_total_amount" value="{{ original_total_amount|default:total_amount }}" />
                         <input type="hidden" name="booking_option" value="{{ booking_option }}" />
                         <input type="hidden" name="travel_option" value="{{ travel_option }}" />
                         <input type="hidden" name="razorpay_order_id" value="{{ razorpay_order_id }}" />
@@ -110,12 +111,21 @@
                                 <td class="pro__title">Count</td>
                                 <td class="pro__price">{{ count }}</td>
                             </tr>
+                            {% if discount_applied %}
+                            <tr>
+                                <td class="pro__title">Original Total</td>
+                                <td class="pro__price"><s>₹{{ original_total_amount }}</s></td>
+                            </tr>
+                            <tr>
+                                <td class="pro__title pro__title--total">Discounted Total</td>
+                                <td class="pro__price pro__price--total">₹{{ total_amount }}</td>
+                            </tr>
+                            {% else %}
                             <tr>
                                 <td class="pro__title pro__title--total">Total</td>
-                                <td class="pro__price pro__price--total">
-                                    ₹{{ total_amount }}
-                                </td>
+                                <td class="pro__price pro__price--total">₹{{ total_amount }}</td>
                             </tr>
+                            {% endif %}
                         </tbody>
                     </table>
                 </div>

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.utils import timezone
+
+from accounts.models import Subscription
 
 
 class CheckoutViewTests(TestCase):
@@ -27,4 +30,12 @@ class CheckoutViewTests(TestCase):
         url = reverse('checkout') + '?count=1&total_amount=1000&booking_option=family&travel_option=Bus'
         response = self.client.get(url)
         self.assertRedirects(response, reverse('accounts:verify_email'))
+
+    def test_discount_applied_for_active_subscription(self):
+        Subscription.objects.create(user=self.user, start_date=timezone.now().date(), active=True)
+        self.client.login(username="tester", password="pass12345")
+        response = self.client.get(reverse('checkout') + '?count=1&total_amount=1000&booking_option=family')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['total_amount'], '900')
+        self.assertEqual(response.context['original_total_amount'], '1000')
 

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,7 +1,12 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.utils import timezone
+from decimal import Decimal
 from unittest.mock import patch
+
+from accounts.models import Subscription
+from tour.models import Order
 
 class VerifyPaymentViewTests(TestCase):
     def setUp(self):
@@ -42,4 +47,31 @@ class VerifyPaymentViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'thank_you.html')
         self.assertContains(response, 'John')
+
+    @patch('holytrail.views.razorpay.Client')
+    def test_discount_amount_validated(self, mock_client):
+        self.client.login(username="tester", password="pass12345")
+        Subscription.objects.create(user=self.user, start_date=timezone.now().date(), active=True)
+        mock_client.return_value.utility.verify_payment_signature.return_value = None
+        data = {
+            'razorpay_order_id': 'order_123',
+            'razorpay_payment_id': 'payment_123',
+            'razorpay_signature': 'sig_123',
+            'first_name': 'John',
+            'phone': '1234567890',
+            'address': '123 Street',
+            'town-city': 'Townsville',
+            'state': 'State',
+            'zip-code': '12345',
+            'email': 'john@example.com',
+            'booking_option': 'family',
+            'travel_option': 'Bus',
+            'count': '2',
+            'total_amount': '900',
+            'original_total_amount': '1000',
+        }
+        response = self.client.post(reverse('verify_payment'), data)
+        self.assertEqual(response.status_code, 200)
+        order = Order.objects.get()
+        self.assertEqual(order.total_amount, Decimal('900'))
 


### PR DESCRIPTION
## Summary
- Apply 10% discount for users with an active subscription less than a year old at checkout.
- Validate and recompute discounted totals server-side before creating orders.
- Show original and discounted totals on the checkout page when a subscription discount is applied.
- Cover discount behavior with new unit tests.

## Testing
- ⚠️ `pytest` *(missing Django dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a00602fe74832db62add09929d4f4e