### PR TITLE
Display subscription details on dashboard

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -257,10 +257,28 @@ def reset_password_view(request):
 def dashboard_view(request):
     user = request.user
     orders = Order.objects.filter(user=user)
+
+    # Retrieve the user's active subscription, if any
+    subscription = (
+        Subscription.objects.filter(user=user, active=True)
+        .order_by("-start_date")
+        .first()
+    )
+
+    # Calculate remaining days for the subscription
+    remaining_days = None
+    if subscription and subscription.end_date:
+        remaining_days = (subscription.end_date - timezone.now().date()).days
+
     return render(
         request,
         "accounts/dashboard.html",
-        {"user": user, "orders": orders},
+        {
+            "user": user,
+            "orders": orders,
+            "subscription": subscription,
+            "remaining_days": remaining_days,
+        },
     )
 
 

--- a/templates/accounts/dashboard.html
+++ b/templates/accounts/dashboard.html
@@ -21,6 +21,16 @@
         <p><strong>Username:</strong> {{ user.username }}</p>
         <p><strong>Email:</strong> {{ user.email }}</p>
 
+        <h3>Subscription</h3>
+        {% if subscription %}
+        <p><strong>Start Date:</strong> {{ subscription.start_date }}</p>
+        <p><strong>End Date:</strong> {{ subscription.end_date }}</p>
+        <p><strong>Days Remaining:</strong> {{ remaining_days }}</p>
+        {% else %}
+        <p>No active subscription.</p>
+        {% endif %}
+        <p><a href="{% url 'accounts:subscribe' %}">Renew Subscription</a></p>
+
         <h3>Your Orders</h3>
         <table class="table">
             <thead>


### PR DESCRIPTION
## Summary
- Show user's active subscription and remaining days on dashboard
- Render subscription info and renew link in dashboard template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a00723ca34832daf9a8019ee43dc66