### PR TITLE
Add subscription purchase and discount expiry tests

### DIFF
--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 from decimal import Decimal
 from unittest.mock import patch
+from datetime import timedelta
 
 from accounts.models import Subscription
 from tour.models import Order
@@ -74,4 +75,57 @@ class VerifyPaymentViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         order = Order.objects.get()
         self.assertEqual(order.total_amount, Decimal('900'))
+
+    @patch('holytrail.views.razorpay.Client')
+    def test_discount_not_applied_after_expiry(self, mock_client):
+        self.client.login(username="tester", password="pass12345")
+        Subscription.objects.create(
+            user=self.user,
+            start_date=timezone.now().date() - timedelta(days=366),
+            active=True,
+        )
+        mock_client.return_value.utility.verify_payment_signature.return_value = None
+        data = {
+            'razorpay_order_id': 'order_123',
+            'razorpay_payment_id': 'payment_123',
+            'razorpay_signature': 'sig_123',
+            'first_name': 'John',
+            'phone': '1234567890',
+            'address': '123 Street',
+            'town-city': 'Townsville',
+            'state': 'State',
+            'zip-code': '12345',
+            'email': 'john@example.com',
+            'booking_option': 'family',
+            'travel_option': 'Bus',
+            'count': '2',
+            'total_amount': '1000',
+            'original_total_amount': '1000',
+        }
+        response = self.client.post(reverse('verify_payment'), data)
+        self.assertEqual(response.status_code, 200)
+        order = Order.objects.get()
+        self.assertEqual(order.total_amount, Decimal('1000'))
+
+
+class VerifySubscriptionPaymentViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass12345")
+
+    @patch('accounts.views.razorpay.Client')
+    def test_subscription_created_on_successful_payment(self, mock_client):
+        self.client.login(username="tester", password="pass12345")
+        mock_client.return_value.utility.verify_payment_signature.return_value = None
+        data = {
+            'razorpay_order_id': 'order_123',
+            'razorpay_payment_id': 'payment_123',
+            'razorpay_signature': 'sig_123',
+        }
+        response = self.client.post(reverse('accounts:verify_subscription_payment'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'subscription_success.html')
+        subscription = Subscription.objects.get()
+        self.assertEqual(subscription.user, self.user)
+        self.assertTrue(subscription.active)
+        self.assertEqual(subscription.start_date, timezone.now().date())
 


### PR DESCRIPTION
## Summary
- Add tests that simulate successful subscription purchase and verify Subscription creation
- Ensure subscription discounts do not apply after 365 days
- Cover expired subscription scenario during payment validation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a007cc00f8832d8d42990035694331