### PR TITLE
Simplify checkout order summary

### DIFF
--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -97,28 +97,13 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td class="pro__title">Booking Option</td>
+                                <td class="pro__title">Package Tier</td>
                                 <td class="pro__price">{{ booking_option }}</td>
                             </tr>
-                            <tr>
-                                <td class="pro__title">Count</td>
-                                <td class="pro__price">{{ count }}</td>
-                            </tr>
-                            {% if discount_applied %}
-                            <tr>
-                                <td class="pro__title">Original Total</td>
-                                <td class="pro__price"><s>₹{{ original_total_amount }}</s></td>
-                            </tr>
-                            <tr>
-                                <td class="pro__title pro__title--total">Discounted Total</td>
-                                <td class="pro__price pro__price--total">₹{{ total_amount }}</td>
-                            </tr>
-                            {% else %}
                             <tr>
                                 <td class="pro__title pro__title--total">Total</td>
                                 <td class="pro__price pro__price--total">₹{{ total_amount }}</td>
                             </tr>
-                            {% endif %}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
## Summary
- streamline checkout order table to show only package tier and total

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b11b814832d874d70657b2d4af2