### PR TITLE
Remove travel option column from dashboard

### DIFF
--- a/templates/accounts/dashboard.html
+++ b/templates/accounts/dashboard.html
@@ -36,7 +36,6 @@
             <thead>
                 <tr>
                     <th>ID</th>
-                    <th>Booking Option</th>
                     <th>Total Amount</th>
                     <th>Created</th>
                 </tr>
@@ -45,13 +44,12 @@
                 {% for order in orders %}
                 <tr>
                     <td>{{ order.id }}</td>
-                    <td>{{ order.get_booking_option_display }}</td>
                     <td>{{ order.total_amount }}</td>
                     <td>{{ order.created_at }}</td>
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="4">No orders found.</td>
+                    <td colspan="3">No orders found.</td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
## Summary
- drop the unused booking/travel option column from the account dashboard orders table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a45d7e98c8832d98a34efe933e9dec