### PR TITLE
Add star rating widget to feedback form

### DIFF
--- a/static/css/gotur.css
+++ b/static/css/gotur.css
@@ -18401,3 +18401,86 @@ figure.image_resized {
   width: 100% !important;
   max-width: 100% !important;
 }
+
+/*--------------------------------------------------------------
+# Star Rating Widget
+--------------------------------------------------------------*/
+.star-rating {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.star-rating__stars {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 0.4rem;
+}
+
+.star-rating__option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.star-rating__option--star {
+  font-size: 1.6rem;
+  color: var(--gotur-border-color);
+}
+
+.star-rating__icon {
+  pointer-events: none;
+}
+
+.star-rating__radio {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+}
+
+.star-rating__radio:focus-visible + .star-rating__option {
+  outline: 2px solid var(--gotur-primary);
+  outline-offset: 2px;
+}
+
+.star-rating__option--star.is-active .star-rating__icon {
+  color: var(--gotur-primary);
+}
+
+.star-rating__option--star:hover .star-rating__icon {
+  color: var(--gotur-primary);
+}
+
+.star-rating__radio:checked + .star-rating__option .star-rating__icon,
+.star-rating__radio:checked + .star-rating__option ~ .star-rating__option .star-rating__icon {
+  color: var(--gotur-primary);
+}
+
+.star-rating__clear {
+  display: inline-flex;
+  align-items: center;
+}
+
+.star-rating__option--clear {
+  font-size: 0.95rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--gotur-border-color);
+  border-radius: 999px;
+  color: var(--gotur-text);
+}
+
+.star-rating__option--clear:hover,
+.star-rating__option--clear.is-active {
+  background-color: var(--gotur-primary);
+  border-color: var(--gotur-primary);
+  color: var(--gotur-white);
+}
+
+.star-rating__clear-text {
+  font-weight: 500;
+}

--- a/static/js/feedback-rating.js
+++ b/static/js/feedback-rating.js
@@ -1,0 +1,64 @@
+(function () {
+    function initStarRating(rating) {
+        var stars = Array.prototype.slice.call(rating.querySelectorAll('.star-rating__option--star'));
+        var radios = Array.prototype.slice.call(rating.querySelectorAll('.star-rating__radio'));
+        var clearLabel = rating.querySelector('.star-rating__option--clear');
+
+        function getCheckedValue() {
+            var checked = rating.querySelector('.star-rating__radio:checked');
+            return checked ? parseInt(checked.value, 10) : 0;
+        }
+
+        function applyState(value) {
+            if (value === undefined || value === null) {
+                value = getCheckedValue();
+            }
+            stars.forEach(function (star) {
+                var starValue = parseInt(star.getAttribute('data-value'), 10);
+                star.classList.toggle('is-active', value > 0 && starValue <= value);
+            });
+            if (clearLabel) {
+                clearLabel.classList.toggle('is-active', value === 0);
+            }
+        }
+
+        function preview(value) {
+            applyState(value);
+        }
+
+        stars.forEach(function (star) {
+            var value = parseInt(star.getAttribute('data-value'), 10);
+            star.addEventListener('mouseenter', function () {
+                preview(value);
+            });
+            star.addEventListener('mouseleave', function () {
+                preview();
+            });
+        });
+
+        if (clearLabel) {
+            clearLabel.addEventListener('mouseenter', function () {
+                preview(0);
+            });
+            clearLabel.addEventListener('mouseleave', function () {
+                preview();
+            });
+        }
+
+        radios.forEach(function (radio) {
+            radio.addEventListener('change', function () {
+                applyState(parseInt(radio.value, 10));
+            });
+        });
+
+        applyState();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.star-rating').forEach(initStarRating);
+        });
+    } else {
+        document.querySelectorAll('.star-rating').forEach(initStarRating);
+    }
+})();

--- a/templates/tour/feedback.html
+++ b/templates/tour/feedback.html
@@ -61,61 +61,24 @@
                                 </div>
                                 {% endif %}
                             </div>
-                            <div class="form-one__control form-one__control--full">
-                                <label for="{{ form.overall_rating.id_for_label }}">{{ form.overall_rating.label }}</label>
-                                {{ form.overall_rating }}
-                                <small class="form-text text-muted">Rate your journey overall on a scale of 0 to 5.</small>
-                                {% if form.overall_rating.errors %}
+                            {% with rating_field_names='overall_rating travel_experience accommodation fooding tour_guide knowledge_sharing' %}
+                            {% for field in form %}
+                            {% if field.name in rating_field_names %}
+                            <div class="form-one__control{% if field.name == 'overall_rating' %} form-one__control--full{% endif %}">
+                                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                {{ field }}
+                                {% if field.name == 'overall_rating' %}
+                                <small class="form-text text-muted">Select up to five stars to rate your journey overall.</small>
+                                {% endif %}
+                                {% if field.errors %}
                                 <div class="invalid-feedback d-block">
-                                    {% for error in form.overall_rating.errors %}{{ error }}{% endfor %}
+                                    {% for error in field.errors %}{{ error }}{% endfor %}
                                 </div>
                                 {% endif %}
                             </div>
-                            <div class="form-one__control">
-                                <label for="{{ form.travel_experience.id_for_label }}">{{ form.travel_experience.label }}</label>
-                                {{ form.travel_experience }}
-                                {% if form.travel_experience.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.travel_experience.errors %}{{ error }}{% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
-                            <div class="form-one__control">
-                                <label for="{{ form.accommodation.id_for_label }}">{{ form.accommodation.label }}</label>
-                                {{ form.accommodation }}
-                                {% if form.accommodation.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.accommodation.errors %}{{ error }}{% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
-                            <div class="form-one__control">
-                                <label for="{{ form.fooding.id_for_label }}">{{ form.fooding.label }}</label>
-                                {{ form.fooding }}
-                                {% if form.fooding.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.fooding.errors %}{{ error }}{% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
-                            <div class="form-one__control">
-                                <label for="{{ form.tour_guide.id_for_label }}">{{ form.tour_guide.label }}</label>
-                                {{ form.tour_guide }}
-                                {% if form.tour_guide.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.tour_guide.errors %}{{ error }}{% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
-                            <div class="form-one__control">
-                                <label for="{{ form.knowledge_sharing.id_for_label }}">{{ form.knowledge_sharing.label }}</label>
-                                {{ form.knowledge_sharing }}
-                                {% if form.knowledge_sharing.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.knowledge_sharing.errors %}{{ error }}{% endfor %}
-                                </div>
-                                {% endif %}
-                            </div>
+                            {% endif %}
+                            {% endfor %}
+                            {% endwith %}
                             <div class="form-one__control form-one__control--full">
                                 <label for="{{ form.overall_experience.id_for_label }}">{{ form.overall_experience.label }}</label>
                                 {{ form.overall_experience }}
@@ -146,4 +109,5 @@
         </div>
     </div>
 </section>
+<script src="{% static 'js/feedback-rating.js' %}"></script>
 {% endblock %}

--- a/templates/tour/widgets/star_rating.html
+++ b/templates/tour/widgets/star_rating.html
@@ -1,0 +1,21 @@
+{% load static %}
+<div class="star-rating" data-field-name="{{ widget.name }}">
+    <div class="star-rating__stars" role="radiogroup">
+        {% for group, options, index in widget.optgroups %}
+            {% for option in options %}
+                {% if option.value|stringformat:'s' != '0' %}
+                    {% include widget.option_template_name with widget=option %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    </div>
+    <div class="star-rating__clear">
+        {% for group, options, index in widget.optgroups %}
+            {% for option in options %}
+                {% if option.value|stringformat:'s' == '0' %}
+                    {% include widget.option_template_name with widget=option %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    </div>
+</div>

--- a/templates/tour/widgets/star_rating_option.html
+++ b/templates/tour/widgets/star_rating_option.html
@@ -1,0 +1,12 @@
+{% if widget.value|stringformat:'s' == '0' %}
+<input type="{{ widget.type }}" name="{{ widget.name }}" value="{{ widget.value|stringformat:'s' }}" class="star-rating__radio star-rating__radio--clear"{% include "django/forms/widgets/attrs.html" %}{% if widget.is_checked %} checked{% endif %}>
+<label for="{{ widget.attrs.id }}" class="star-rating__option star-rating__option--clear" aria-label="Clear rating">
+    <span class="star-rating__clear-text">Clear</span>
+</label>
+{% else %}
+<input type="{{ widget.type }}" name="{{ widget.name }}" value="{{ widget.value|stringformat:'s' }}" class="star-rating__radio"{% include "django/forms/widgets/attrs.html" %}{% if widget.is_checked %} checked{% endif %}>
+<label for="{{ widget.attrs.id }}" class="star-rating__option star-rating__option--star" data-value="{{ widget.value }}" aria-label="{{ widget.label }} star{% if widget.label != '1' %}s{% endif %}">
+    <i class="fa-solid fa-star star-rating__icon" aria-hidden="true"></i>
+    <span class="visually-hidden">{{ widget.label }} star{% if widget.label != '1' %}s{% endif %}</span>
+</label>
+{% endif %}

--- a/tour/forms.py
+++ b/tour/forms.py
@@ -3,6 +3,14 @@ from django import forms
 from .models import Feedback
 
 
+STAR_CHOICES = [(value, str(value)) for value in range(5, -1, -1)]
+
+
+class StarRatingWidget(forms.RadioSelect):
+    template_name = "tour/widgets/star_rating.html"
+    option_template_name = "tour/widgets/star_rating_option.html"
+
+
 class FeedbackForm(forms.ModelForm):
     class Meta:
         model = Feedback
@@ -46,13 +54,9 @@ class FeedbackForm(forms.ModelForm):
             if field_name in rating_fields:
                 field.min_value = 0
                 field.max_value = 5
-                field.widget = forms.NumberInput(
-                    attrs={
-                        "class": "form-control",
-                        "min": 0,
-                        "max": 5,
-                    }
-                )
+                field.choices = STAR_CHOICES
+                field.widget = StarRatingWidget()
+                field.widget.choices = STAR_CHOICES
             elif field_name in {"overall_experience", "comments"}:
                 field.widget = forms.Textarea(
                     attrs={


### PR DESCRIPTION
## Summary
- replace numeric rating inputs in the tour feedback form with a reusable star-based widget and shared 0–5 choices
- add custom widget templates, styling, and a small script to render accessible Font Awesome stars with a clear option
- refresh the feedback page copy and include the new assets so guests are prompted to select up to five stars

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb44c9734832d94cc110d36a56873