### PR TITLE
Ensure tour feedback email column exists

### DIFF
--- a/tour/migrations/0006_ensure_email_field.py
+++ b/tour/migrations/0006_ensure_email_field.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+
+def ensure_email_field(apps, schema_editor):
+    connection = schema_editor.connection
+    table_name = "tour_feedback"
+
+    with connection.cursor() as cursor:
+        columns = {
+            column.name for column in connection.introspection.get_table_description(cursor, table_name)
+        }
+
+    if "email" in columns:
+        return
+
+    if "mobile_number" in columns:
+        schema_editor.execute(
+            "ALTER TABLE {table} RENAME COLUMN {old} TO {new}".format(
+                table=schema_editor.quote_name(table_name),
+                old=schema_editor.quote_name("mobile_number"),
+                new=schema_editor.quote_name("email"),
+            )
+        )
+        return
+
+    Feedback = apps.get_model("tour", "Feedback")
+    field = Feedback._meta.get_field("email")
+    field.set_attributes_from_name("email")
+    schema_editor.add_field(Feedback, field)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tour", "0005_rename_mobile_number_feedback_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_email_field, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add a data migration that guarantees the `tour_feedback` table has an `email` column by renaming the old `mobile_number` column when present
- add the column automatically if neither `email` nor `mobile_number` exists to keep deployments resilient

## Testing
- not run (Django is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ded0dda7c8832d9d4de516df43c82a